### PR TITLE
Implement `without-aliases`

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject formatting-stack "0.17.0"
+(defproject formatting-stack "0.17.1-alpha1"
   :description "An efficient, smart, graceful composition of formatters, linters and such."
   :url "https://github.com/nedap/formatting-stack"
   :license {:name "Eclipse Public License"

--- a/src/formatting_stack/formatters/clean_ns.clj
+++ b/src/formatting_stack/formatters/clean_ns.clj
@@ -4,19 +4,20 @@
    [formatting-stack.formatters.clean-ns.impl :as impl]
    [formatting-stack.formatters.how-to-ns]
    [formatting-stack.protocols.formatter]
-   [formatting-stack.util :refer [process-in-parallel! try-require]]
+   [formatting-stack.util :refer [process-in-parallel! try-require without-aliases]]
    [medley.core :refer [deep-merge]]
    [refactor-nrepl.config]))
 
 (defn clean! [how-to-ns-opts refactor-nrepl-opts namespaces-that-should-never-cleaned libspec-whitelist filename]
   (let [buffer (slurp filename)
         original-ns-form (how-to-ns/slurp-ns-from-string buffer)]
-    (when-let [clean-ns-form (impl/clean-ns-form {:how-to-ns-opts                       how-to-ns-opts
-                                                  :refactor-nrepl-opts                  refactor-nrepl-opts
-                                                  :filename                             filename
-                                                  :original-ns-form                     (read-string original-ns-form)
-                                                  :namespaces-that-should-never-cleaned namespaces-that-should-never-cleaned
-                                                  :libspec-whitelist                    libspec-whitelist})]
+    (when-let [clean-ns-form (without-aliases
+                               (impl/clean-ns-form {:how-to-ns-opts                       how-to-ns-opts
+                                                    :refactor-nrepl-opts                  refactor-nrepl-opts
+                                                    :filename                             filename
+                                                    :original-ns-form                     (read-string original-ns-form)
+                                                    :namespaces-that-should-never-cleaned namespaces-that-should-never-cleaned
+                                                    :libspec-whitelist                    libspec-whitelist}))]
       (when-not (= original-ns-form clean-ns-form)
         (println "Cleaning unused imports:" filename)
         (->> original-ns-form

--- a/src/formatting_stack/linters/eastwood.clj
+++ b/src/formatting_stack/linters/eastwood.clj
@@ -1,17 +1,17 @@
 (ns formatting-stack.linters.eastwood
   (:require
    [clojure.string :as str]
-   [eastwood.lint :as eastwood]
+   [eastwood.lint]
    [eastwood.util]
    [formatting-stack.protocols.linter]
-   [formatting-stack.util :refer [ns-name-from-filename]]
+   [formatting-stack.util :refer [ns-name-from-filename without-aliases]]
    [medley.core :refer [deep-merge]]))
 
 (def default-eastwood-options
   ;; Avoid false positives or more-annoying-than-useful checks:
   (let [linters (remove #{:suspicious-test :unused-ret-vals :constant-test :wrong-tag}
-                        eastwood/default-linters)]
-    (-> eastwood/default-opts
+                        eastwood.lint/default-linters)]
+    (-> eastwood.lint/default-opts
         (assoc :linters linters))))
 
 (def default-warnings-to-silence
@@ -36,8 +36,9 @@
           warnings-to-silence (or warnings-to-silence default-warnings-to-silence)
           result (->> (with-out-str
                         (binding [*warn-on-reflection* true]
-                          (eastwood/eastwood (-> options
-                                                 (assoc :namespaces namespaces)))))
+                          (without-aliases
+                            (eastwood.lint/eastwood (-> options
+                                                        (assoc :namespaces namespaces))))))
                       (str/split-lines)
                       (remove (fn [line]
                                 (or (str/blank? line)

--- a/src/formatting_stack/project_parsing.clj
+++ b/src/formatting_stack/project_parsing.clj
@@ -1,0 +1,32 @@
+(ns formatting-stack.project-parsing
+  (:require
+   [clojure.java.classpath :as classpath]
+   [clojure.java.io :as io]
+   [clojure.tools.namespace.file :as file]
+   [clojure.tools.namespace.find :as find]
+   [clojure.tools.namespace.parse :as parse])
+  (:import
+   (java.io File)))
+
+(defn find-files [dirs platform]
+  (->> dirs
+       (map io/file)
+       (map #(.getCanonicalFile ^File %))
+       (filter #(.exists ^File %))
+       (mapcat #(find/find-sources-in-dir % platform))
+       (map #(.getCanonicalFile ^File %))))
+
+(defn project-namespaces
+  "Returns all the namespaces contained or required in the current project.
+
+  Includes third-party dependencies."
+  []
+  (->> (find-files (classpath/classpath-directories) find/clj)
+       (mapcat (fn [file]
+                 (let [decl (-> file file/read-file-ns-decl)
+                       n (-> decl parse/name-from-ns-decl)
+                       deps (-> decl parse/deps-from-ns-decl)]
+                   (conj deps n))))
+       (distinct)
+       (filter identity)
+       (keep find-ns)))


### PR DESCRIPTION
Fixes #68

@jwkoelewijn had experienced the issue of seeing `IllegalStateException Alias _ already exists in namespace _` in Cursive. Personally never had, myself

This is a blind (but educated ;p) attempt at fixing it.

My guess is that Eastwood calls [analyze+eval](https://github.com/clojure/tools.analyzer.jvm/blob/7572424fffe83518d123788259879c82002a1129/src/main/clojure/clojure/tools/analyzer/jvm.clj#L477) in an order which is unrelated to the order in which tools.namespace performs code reloading. So this eval-ing can perform ns alias operations, which would clash with the already-loaded code.

Hence the new `without-aliases` macro.

## Testing plan

Install f-s `0.17.1-alpha1` and check if things work as usual.

* Can you trigger Eastwood twice in a row?
* Does the repl keep working after that?
* Does any error pop up?