### PR TITLE
Handle nil namespaces

### DIFF
--- a/src/formatting_stack/linters/eastwood.clj
+++ b/src/formatting_stack/linters/eastwood.clj
@@ -30,8 +30,7 @@
     (reset! eastwood.util/warning-enable-config-atom []) ;; https://github.com/jonase/eastwood/issues/317
     (let [namespaces (->> filenames
                           (remove #(str/ends-with? % ".edn"))
-                          (map ns-name-from-filename)
-                          (filter some?))
+                          (keep ns-name-from-filename))
           options (deep-merge default-eastwood-options
                               (or eastwood-options {}))
           warnings-to-silence (or warnings-to-silence default-warnings-to-silence)


### PR DESCRIPTION
## Brief

Ran into a case where a scratchfile without a namespace opaquely crashed eastwood

<details>

```
java.lang.NullPointerException                                                                                   [62/4775]
        at java.util.concurrent.ConcurrentHashMap.get(ConcurrentHashMap.java:936)
        at clojure.lang.Namespace.findOrCreate(Namespace.java:173)
        at clojure.core$create_ns.invokeStatic(core.clj:4138)
        at clojure.core$create_ns.invoke(core.clj:4132)                                        
        at eastwood.lint$eastwood_core.invokeStatic(lint.clj:439)                        
        at eastwood.lint$eastwood_core.invoke(lint.clj:398)                                                             
        at eastwood.lint$eastwood.invokeStatic(lint.clj:527)
        at eastwood.lint$eastwood.invoke(lint.clj:507)                                             
        at eastwood.lint$eastwood.invokeStatic(lint.clj:508)                             
        at eastwood.lint$eastwood.invoke(lint.clj:507)
        at formatting_stack.linters.eastwood.Eastwood$fn__25278$fn__25279.invoke(eastwood.clj:40)
        at formatting_stack.linters.eastwood.Eastwood$fn__25278.invoke(eastwood.clj:38)                                   
        at formatting_stack.linters.eastwood.Eastwood.lint_BANG_(eastwood.clj:37)
        at formatting_stack.protocols.linter$eval17512$fn__17513$G__17504__17516.invoke(linter.clj:3)
        at formatting_stack.protocols.linter$eval17512$fn__17513$G__17503__17520.invoke(linter.clj:3)
        at formatting_stack.core$process_BANG_$fn__27091.invoke(core.clj:50)
        at formatting_stack.core$process_BANG_.invokeStatic(core.clj:49)
        at formatting_stack.core$process_BANG_.invoke(core.clj:33)
        at formatting_stack.core$format_BANG_$fn__27103.invoke(core.clj:84)
        at clojure.lang.AFn.applyToHelper(AFn.java:152)
        at clojure.lang.AFn.applyTo(AFn.java:144)
        at clojure.core$apply.invokeStatic(core.clj:665)
        at clojure.core$with_bindings_STAR_.invokeStatic(core.clj:1973)
        at clojure.core$with_bindings_STAR_.doInvoke(core.clj:1973)
        at clojure.lang.RestFn.invoke(RestFn.java:425)
        at clojure.lang.AFn.applyToHelper(AFn.java:156)
        at clojure.lang.RestFn.applyTo(RestFn.java:132)
        at clojure.core$apply.invokeStatic(core.clj:669)
        at clojure.core$bound_fn_STAR_$fn__5749.doInvoke(core.clj:2003)
        at clojure.lang.RestFn.invoke(RestFn.java:397)
        at formatting_stack.core$format_BANG_.invokeStatic(core.clj:93)
        at formatting_stack.core$format_BANG_.doInvoke(core.clj:56)
        at clojure.lang.RestFn.invoke(RestFn.java:805)
        at formatting_stack.project_formatter$format_and_lint_project_BANG_.invokeStatic(project_formatter.clj:60)
        at formatting_stack.project_formatter$format_and_lint_project_BANG_.doInvoke(project_formatter.clj:58)
        at clojure.lang.RestFn.invoke(RestFn.java:397)
        at dev$eval119929.invokeStatic(form-init1547367617445383131.clj:1)
        at dev$eval119929.invoke(form-init1547367617445383131.clj:1)
        at clojure.lang.Compiler.eval(Compiler.java:7177)
        at clojure.lang.Compiler.eval(Compiler.java:7132)
        at clojure.core$eval.invokeStatic(core.clj:3214)
        at clojure.core$eval.invoke(core.clj:3210)
        at clojure.main$repl$read_eval_print__9086$fn__9089.invoke(main.clj:437)
        at clojure.main$repl$read_eval_print__9086.invoke(main.clj:437)
        at clojure.main$repl$fn__9095.invoke(main.clj:458)
        at clojure.main$repl.invokeStatic(main.clj:458)
        at clojure.main$repl.doInvoke(main.clj:368)
        at clojure.lang.RestFn.invoke(RestFn.java:1523)
        at nrepl.middleware.interruptible_eval$evaluate.invokeStatic(interruptible_eval.clj:79)
        at nrepl.middleware.interruptible_eval$evaluate.invoke(interruptible_eval.clj:55)
        at nrepl.middleware.interruptible_eval$interruptible_eval$fn__68221$fn__68225.invoke(interruptible_eval.clj:142)
        at clojure.lang.AFn.run(AFn.java:22)
        at nrepl.middleware.session$session_exec$main_loop__68322$fn__68326.invoke(session.clj:171)
        at nrepl.middleware.session$session_exec$main_loop__68322.invoke(session.clj:170)
        at clojure.lang.AFn.run(AFn.java:22)
        at java.lang.Thread.run(Thread.java:748)
```
</details>

## QA plan

1. add empty `t.clj` in project root
1. run `format-and-lint-branch!`

<!-- Please state a reproducible plan to prove this PR works. Attach screenshots, gifs, etc. if needed. Occasionally, sufficient test coverage removes the need for QAing. -->

## Author checklist

<!-- Please, before publicizing your PR, open it as a "WIP PR", and then review it using the following. -->

* [x] I have QAed the functionality
* [x] The PR has a reasonably reviewable size and a meaningful commit history
* [x] I have run the [branch formatter](https://github.com/nedap/formatting-stack/blob/332a419034ab46fad526a5592f4257353bd695b6/src/formatting_stack/branch_formatter.clj) and observed no new/significative warnings
* [ ] The build passes
* [x] I have self-reviewed the PR prior to assignment
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [x] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Modular design
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
  * [ ] Cross-compatibility (Clojure/ClojureScript)

## Reviewer checklist

* [ ] I have checked out this branch and reviewed it locally, running it
* [ ] I have QAed the functionality
* [ ] I have reviewed the PR
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [ ] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Modular design
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
  * [ ] Cross-compatibility (Clojure/ClojureScript)
