### PR TITLE
Make `refactor-nrepl` dependency optional

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ commands:
             - v1-dependencies-{{ checksum "project.clj" }}
             # fallback to using the latest cache if no exact match is found
             - v1-dependencies-
-      - run: lein with-profile -dev,+test,+ci,+cider-nrepl deps
+      - run: lein with-profile -dev,+test,+ci,+refactor-nrepl deps
       - save_cache:
           paths:
             - ~/.m2
@@ -30,8 +30,11 @@ jobs:
     steps:
       - setup-env
       - run:
-          name: 'Run JVM tests'
-          command: lein with-profile -dev,+ci,+cider-nrepl test
+          name: 'Run JVM tests, including refactor-nrepl functionality'
+          command: lein with-profile -dev,+ci,+refactor-nrepl do clean, test
+      - run:
+          name: 'Run JVM tests, excluding refactor-nrepl functionality'
+          command: lein with-profile -dev,+ci do clean, test
   deploy:
     executor: lein-executor
     steps:

--- a/README.md
+++ b/README.md
@@ -77,9 +77,10 @@ The general intent is to make formatting:
 [formatting-stack "2.0.0-alpha1"]
 ```
 
-**Also** you have to add the latest [cider-nrepl](https://clojars.org/cider/cider-nrepl).
-* It's a transitive, non-automatically-fetched dependency of refactor-nrepl.
-* Sadly we cannot just add it to our project.clj, since it would affect users of lower cider-nrepl versions.
+**Also** you might have to add the [refactor-nrepl](https://github.com/clojure-emacs/refactor-nrepl) dependency.
+  * If you use tooling like CIDER, typically this dependency will be already injected into your classpath, so no action required in this case.
+  * Else, please add the latest version to your project (or personal [profile](https://github.com/technomancy/leiningen/blob/072dcd62dea0ea46413cf938878e2d31b76357c9/doc/PROFILES.md)).
+  * If this dependency isn't added, formatting-stack will degrade gracefully, using slightly fewer formatters/linters.
 
 ### Component/Integrant integration
 

--- a/project.clj
+++ b/project.clj
@@ -17,7 +17,6 @@
                  [org.clojure/clojure "1.10.1"]
                  [org.clojure/tools.namespace "0.3.1"]
                  [org.clojure/tools.reader "1.3.2"]
-                 [refactor-nrepl "2.4.0"]
                  [rewrite-clj "0.6.1"]]
 
   :description "An efficient, smart, graceful composition of formatters, linters and such."
@@ -60,29 +59,30 @@
   ;;   * e.g. criterium, deep-diff, clj-java-decompiler
 
   ;; NOTE: deps marked with #_"transitive" are there to satisfy the `:pedantic?` option.
-  :profiles {:dev         {:dependencies [[com.clojure-goes-fast/clj-java-decompiler "0.2.1"]
-                                          [com.stuartsierra/component "0.4.0"]
-                                          [com.taoensso/timbre "4.10.0"]
-                                          [criterium "0.4.5"]
-                                          [lambdaisland/deep-diff "0.0-29"]
-                                          [org.clojure/core.async "0.5.527"]
-                                          [org.clojure/math.combinatorics "0.1.1"]
-                                          [org.clojure/test.check "0.10.0-alpha3"]]
-                           :jvm-opts     ["-Dclojure.compiler.disable-locals-clearing=true"]
-                           :source-paths ["dev"]
-                           :repl-options {:init-ns dev}}
+  :profiles {:dev            {:dependencies [[com.clojure-goes-fast/clj-java-decompiler "0.2.1"]
+                                             [com.stuartsierra/component "0.4.0"]
+                                             [com.taoensso/timbre "4.10.0"]
+                                             [criterium "0.4.5"]
+                                             [lambdaisland/deep-diff "0.0-29"]
+                                             [org.clojure/core.async "0.5.527"]
+                                             [org.clojure/math.combinatorics "0.1.1"]
+                                             [org.clojure/test.check "0.10.0-alpha3"]]
+                              :jvm-opts     ["-Dclojure.compiler.disable-locals-clearing=true"]
+                              :source-paths ["dev"]
+                              :repl-options {:init-ns dev}}
 
              ;; `dev` in :test is important - a test depends on it:
-             :test        {:source-paths   ["dev"]
-                           :dependencies   [[com.nedap.staffing-solutions/utils.test "1.6.2"]]
-                           :jvm-opts       ["-Dclojure.core.async.go-checking=true"
-                                            "-Duser.language=en-US"]
-                           :resource-paths ["test-resources-extra"
-                                            "test-resources"]}
+             :test           {:source-paths   ["dev"]
+                              :dependencies   [[com.nedap.staffing-solutions/utils.test "1.6.2"]]
+                              :jvm-opts       ["-Dclojure.core.async.go-checking=true"
+                                               "-Duser.language=en-US"]
+                              :resource-paths ["test-resources-extra"
+                                               "test-resources"]}
 
-             :cider-nrepl {:plugins [[cider/cider-nrepl "0.21.1"]]}
+             :refactor-nrepl {:dependencies [[refactor-nrepl "2.4.0"]]
+                              :plugins      [[cider/cider-nrepl "0.21.1"]]}
 
-             :ci          {:pedantic?    :abort
-                           :jvm-opts     ["-Dclojure.main.report=stderr"]
-                           :global-vars  {*assert* true} ;; `ci.release-workflow` relies on runtime assertions
-                           :dependencies [[com.nedap.staffing-solutions/ci.release-workflow "1.6.0"]]}})
+             :ci             {:pedantic?    :abort
+                              :jvm-opts     ["-Dclojure.main.report=stderr"]
+                              :global-vars  {*assert* true} ;; `ci.release-workflow` relies on runtime assertions
+                              :dependencies [[com.nedap.staffing-solutions/ci.release-workflow "1.6.0"]]}})

--- a/src/formatting_stack/branch_formatter.clj
+++ b/src/formatting_stack/branch_formatter.clj
@@ -22,24 +22,28 @@
 (def third-party-indent-specs formatting-stack.indent-specs/default-third-party-indent-specs)
 
 (defn default-formatters [default-strategies]
-  [(formatters.cljfmt/new {:third-party-indent-specs third-party-indent-specs})
-   (-> (formatters.how-to-ns/new {})
-       (assoc :strategies (conj default-strategies
-                                strategies/files-with-a-namespace)))
-   (formatters.no-extra-blank-lines/new)
-   (formatters.newlines/new {})
-   (-> (formatters.trivial-ns-duplicates/new {})
-       (assoc :strategies (conj default-strategies
-                                strategies/files-with-a-namespace
-                                strategies/exclude-edn)))
-   (-> (formatters.clean-ns/new {})
-       (assoc :strategies (conj default-strategies
-                                strategies/files-with-a-namespace
-                                strategies/exclude-cljc
-                                strategies/exclude-cljs
-                                strategies/exclude-edn
-                                strategies/namespaces-within-refresh-dirs-only
-                                strategies/do-not-use-cached-results!)))])
+  (->> [(formatters.cljfmt/new {:third-party-indent-specs third-party-indent-specs})
+        (-> (formatters.how-to-ns/new {})
+            (assoc :strategies (conj default-strategies
+                                     strategies/files-with-a-namespace)))
+        (formatters.no-extra-blank-lines/new)
+        (formatters.newlines/new {})
+        (-> (formatters.trivial-ns-duplicates/new {})
+            (assoc :strategies (conj default-strategies
+                                     strategies/files-with-a-namespace
+                                     strategies/exclude-edn)))
+        (when (strategies/refactor-nrepl-available?)
+          (-> (formatters.clean-ns/new {})
+              (assoc :strategies (conj default-strategies
+                                       strategies/when-refactor-nrepl
+                                       strategies/files-with-a-namespace
+                                       strategies/exclude-cljc
+                                       strategies/exclude-cljs
+                                       strategies/exclude-edn
+                                       strategies/namespaces-within-refresh-dirs-only
+                                       strategies/do-not-use-cached-results!))))]
+
+       (filterv some?)))
 
 (defn default-linters [default-strategies]
   [(-> (linters.ns-aliases/new {})

--- a/src/formatting_stack/defaults.clj
+++ b/src/formatting_stack/defaults.clj
@@ -27,20 +27,24 @@
         ;; making usage more awkward.
         ;; the strategies mechanism needs some rework to avoid this limitation.
         cljfmt-and-how-to-ns-opts (-> opts (assoc :strategies default-strategies))]
-    [(formatters.cljfmt/new cljfmt-and-how-to-ns-opts)
-     (formatters.how-to-ns/new cljfmt-and-how-to-ns-opts)
-     (formatters.no-extra-blank-lines/new)
-     (formatters.newlines/new opts)
-     (formatters.trivial-ns-duplicates/new (assoc opts :strategies (conj default-strategies
-                                                                         strategies/files-with-a-namespace
-                                                                         strategies/exclude-edn)))
-     (formatters.clean-ns/new (assoc opts :strategies (conj default-strategies
-                                                            strategies/files-with-a-namespace
-                                                            strategies/exclude-cljc
-                                                            strategies/exclude-cljs
-                                                            strategies/exclude-edn
-                                                            strategies/namespaces-within-refresh-dirs-only
-                                                            strategies/do-not-use-cached-results!)))]))
+    (->> [(formatters.cljfmt/new cljfmt-and-how-to-ns-opts)
+          (formatters.how-to-ns/new cljfmt-and-how-to-ns-opts)
+          (formatters.no-extra-blank-lines/new)
+          (formatters.newlines/new opts)
+          (formatters.trivial-ns-duplicates/new (assoc opts :strategies (conj default-strategies
+                                                                              strategies/files-with-a-namespace
+                                                                              strategies/exclude-edn)))
+          (when (strategies/refactor-nrepl-available?)
+            (formatters.clean-ns/new (assoc opts :strategies (conj default-strategies
+                                                                   strategies/when-refactor-nrepl
+                                                                   strategies/files-with-a-namespace
+                                                                   strategies/exclude-cljc
+                                                                   strategies/exclude-cljs
+                                                                   strategies/exclude-edn
+                                                                   strategies/namespaces-within-refresh-dirs-only
+                                                                   strategies/do-not-use-cached-results!))))]
+
+         (filterv some?))))
 
 (def default-linters [(-> (linters.ns-aliases/new {})
                           (assoc :strategies (conj extended-strategies

--- a/src/formatting_stack/project_formatter.clj
+++ b/src/formatting_stack/project_formatter.clj
@@ -23,24 +23,28 @@
 (def default-strategies [strategies/all-files])
 
 (def default-formatters
-  [(formatters.cljfmt/new {:third-party-indent-specs third-party-indent-specs})
-   (-> (formatters.how-to-ns/new {})
-       (assoc :strategies (conj default-strategies
-                                strategies/files-with-a-namespace)))
-   (formatters.no-extra-blank-lines/new)
-   (formatters.newlines/new {})
-   (-> (formatters.trivial-ns-duplicates/new {})
-       (assoc :strategies (conj default-strategies
-                                strategies/files-with-a-namespace
-                                strategies/exclude-edn)))
-   (-> (formatters.clean-ns/new {})
-       (assoc :strategies (conj default-strategies
-                                strategies/files-with-a-namespace
-                                strategies/exclude-cljc
-                                strategies/exclude-cljs
-                                strategies/exclude-edn
-                                strategies/namespaces-within-refresh-dirs-only
-                                strategies/do-not-use-cached-results!)))])
+  (->> [(formatters.cljfmt/new {:third-party-indent-specs third-party-indent-specs})
+        (-> (formatters.how-to-ns/new {})
+            (assoc :strategies (conj default-strategies
+                                     strategies/files-with-a-namespace)))
+        (formatters.no-extra-blank-lines/new)
+        (formatters.newlines/new {})
+        (-> (formatters.trivial-ns-duplicates/new {})
+            (assoc :strategies (conj default-strategies
+                                     strategies/files-with-a-namespace
+                                     strategies/exclude-edn)))
+        (when (strategies/refactor-nrepl-available?)
+          (-> (formatters.clean-ns/new {})
+              (assoc :strategies (conj default-strategies
+                                       strategies/when-refactor-nrepl
+                                       strategies/files-with-a-namespace
+                                       strategies/exclude-cljc
+                                       strategies/exclude-cljs
+                                       strategies/exclude-edn
+                                       strategies/namespaces-within-refresh-dirs-only
+                                       strategies/do-not-use-cached-results!))))]
+
+       (filterv some?)))
 
 (def default-linters
   [(-> (linters.ns-aliases/new {})

--- a/src/formatting_stack/util.clj
+++ b/src/formatting_stack/util.clj
@@ -5,7 +5,8 @@
    [medley.core :refer [find-first]]
    [nedap.speced.def :as speced]
    [nedap.utils.collections.eager :refer [partitioning-pmap]]
-   [nedap.utils.collections.seq :refer [distribute-evenly-by]])
+   [nedap.utils.collections.seq :refer [distribute-evenly-by]]
+   [nedap.utils.spec.predicates :refer [present-string?]])
   (:import
    (java.io File)))
 
@@ -90,7 +91,7 @@
 (def require-lock
   (Object.))
 
-(defn try-require [filename]
+(speced/defn try-require [^present-string? filename]
   (try
     (when-let [namespace (some-> filename file/read-file-ns-decl parse/name-from-ns-decl)]
       (locking require-lock

--- a/test/functional/formatting_stack/formatters/clean_ns.clj
+++ b/test/functional/formatting_stack/formatters/clean_ns.clj
@@ -4,6 +4,7 @@
    [formatting-stack.formatters.clean-ns :as sut]
    [formatting-stack.formatters.clean-ns.impl :as impl :refer [ns-form-of]]
    [formatting-stack.formatters.how-to-ns]
+   [formatting-stack.strategies :as strategies]
    [formatting-stack.util.ns :as util.ns]
    [functional.formatting-stack.formatters.clean-ns.should-be-cleaned]
    [functional.formatting-stack.formatters.clean-ns.should-not-be-cleaned]
@@ -45,31 +46,33 @@
 
 (assert should-not-be-cleaned-5)
 
-(deftest used-namespace-names
-  (is (not (seq (impl/used-namespace-names should-be-cleaned-f #{}))))
-  (is (seq (impl/used-namespace-names should-not-be-partially-cleaned-f #{})))
-  (is (seq (impl/used-namespace-names should-not-be-cleaned-f #{})))
-  (is (seq (impl/used-namespace-names should-not-be-cleaned-2-f #{}))))
+(when (strategies/refactor-nrepl-available?)
+  (deftest used-namespace-names
+    (is (not (seq (impl/used-namespace-names should-be-cleaned-f #{}))))
+    (is (seq (impl/used-namespace-names should-not-be-partially-cleaned-f #{})))
+    (is (seq (impl/used-namespace-names should-not-be-cleaned-f #{})))
+    (is (seq (impl/used-namespace-names should-not-be-cleaned-2-f #{})))))
 
-(deftest clean-ns-form
-  (are [op filename ns-form libspec-whitelist namespaces-that-should-never-cleaned]
-       (let [cleaner (sut/make-cleaner formatting-stack.formatters.how-to-ns/default-how-to-ns-opts
-                                       sut/default-nrepl-opts
-                                       namespaces-that-should-never-cleaned
-                                       libspec-whitelist
-                                       filename)
-             v (util.ns/replaceable-ns-form filename cleaner formatting-stack.formatters.how-to-ns/default-how-to-ns-opts)]
-         (op v))
-    some? should-be-cleaned-f               should-be-cleaned               sut/default-libspec-whitelist #{}
-    nil?  should-be-cleaned-f               should-be-cleaned               sut/default-libspec-whitelist #{'functional.formatting-stack.formatters.clean-ns.should-be-cleaned}
-    some? "dev/user.clj"                    (ns-form-of "dev/user.clj")     sut/default-libspec-whitelist #{}
-    nil?  "dev/user.clj"                    (ns-form-of "dev/user.clj")     sut/default-libspec-whitelist sut/default-namespaces-that-should-never-cleaned
-    nil?  should-not-be-partially-cleaned-f should-not-be-partially-cleaned sut/default-libspec-whitelist #{}
-    nil?  should-not-be-cleaned-f           should-not-be-cleaned           sut/default-libspec-whitelist #{}
-    nil?  should-not-be-cleaned-2-f         should-not-be-cleaned-2         sut/default-libspec-whitelist #{}
-    nil?  should-not-be-cleaned-3-f         should-not-be-cleaned-3         sut/default-libspec-whitelist #{}
-    nil?  should-not-be-cleaned-4-f         should-not-be-cleaned-4         sut/default-libspec-whitelist #{}
-    nil?  should-not-be-cleaned-5-f         should-not-be-cleaned-5         sut/default-libspec-whitelist #{}
-    some? should-not-be-cleaned-3-f         should-not-be-cleaned-3         #{}                           #{}
-    some? should-not-be-cleaned-4-f         should-not-be-cleaned-4         #{}                           #{}
-    some? should-not-be-cleaned-5-f         should-not-be-cleaned-5         #{}                           #{}))
+(when (strategies/refactor-nrepl-available?)
+  (deftest clean-ns-form
+    (are [op filename ns-form libspec-whitelist namespaces-that-should-never-cleaned]
+         (let [cleaner (sut/make-cleaner formatting-stack.formatters.how-to-ns/default-how-to-ns-opts
+                                         @sut/default-nrepl-opts
+                                         namespaces-that-should-never-cleaned
+                                         libspec-whitelist
+                                         filename)
+               v (util.ns/replaceable-ns-form filename cleaner formatting-stack.formatters.how-to-ns/default-how-to-ns-opts)]
+           (op v))
+      some? should-be-cleaned-f               should-be-cleaned               sut/default-libspec-whitelist #{}
+      nil?  should-be-cleaned-f               should-be-cleaned               sut/default-libspec-whitelist #{'functional.formatting-stack.formatters.clean-ns.should-be-cleaned}
+      some? "dev/user.clj"                    (ns-form-of "dev/user.clj")     sut/default-libspec-whitelist #{}
+      nil?  "dev/user.clj"                    (ns-form-of "dev/user.clj")     sut/default-libspec-whitelist sut/default-namespaces-that-should-never-cleaned
+      nil?  should-not-be-partially-cleaned-f should-not-be-partially-cleaned sut/default-libspec-whitelist #{}
+      nil?  should-not-be-cleaned-f           should-not-be-cleaned           sut/default-libspec-whitelist #{}
+      nil?  should-not-be-cleaned-2-f         should-not-be-cleaned-2         sut/default-libspec-whitelist #{}
+      nil?  should-not-be-cleaned-3-f         should-not-be-cleaned-3         sut/default-libspec-whitelist #{}
+      nil?  should-not-be-cleaned-4-f         should-not-be-cleaned-4         sut/default-libspec-whitelist #{}
+      nil?  should-not-be-cleaned-5-f         should-not-be-cleaned-5         sut/default-libspec-whitelist #{}
+      some? should-not-be-cleaned-3-f         should-not-be-cleaned-3         #{}                           #{}
+      some? should-not-be-cleaned-4-f         should-not-be-cleaned-4         #{}                           #{}
+      some? should-not-be-cleaned-5-f         should-not-be-cleaned-5         #{}                           #{})))


### PR DESCRIPTION
## Brief

formatting-stack functionality will degrade gracefullly if it's not present.

That is covered by a new CI step.

Fixes nedap/formatting-stack#111

## QA plan

Check in CI that the two `lein test` suites return a differt number of passed assertions.

## Author checklist

<!-- Please, before publicizing your PR, open it as a "WIP PR", and then review it using the following. -->

* [x] I have QAed the functionality
* [x] The PR has a reasonably reviewable size and a meaningful commit history
* [x] I have run the [branch formatter](https://github.com/nedap/formatting-stack/blob/332a419034ab46fad526a5592f4257353bd695b6/src/formatting_stack/branch_formatter.clj) and observed no new/significative warnings
* [x] The build passes
* [x] I have self-reviewed the PR prior to assignment
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [x] Correctness
  * [x] Robustness (red paths, failure handling etc)
  * [ ] Modular design
  * [x] Test coverage
  * [ ] Spec coverage
  * [x] Documentation
  * [x] Security
  * [x] Performance
  * [x] Breaking API changes
  * [x] Cross-compatibility (Clojure/ClojureScript)

## Reviewer checklist

* [x] I have checked out this branch and reviewed it locally, running it
* [x] I have QAed the functionality
* [x] I have reviewed the PR
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [x] Correctness
  * [x] Robustness (red paths, failure handling etc)
  * [ ] Modular design
  * [x] Test coverage
  * [ ] Spec coverage
  * [x] Documentation
  * [ ] Security
  * [ ] Performance
  * [x] Breaking API changes
  * [ ] Cross-compatibility (Clojure/ClojureScript)
