### PR TITLE
Fix pre-post destructure

### DIFF
--- a/src/formatting_stack/linters/eastwood.clj
+++ b/src/formatting_stack/linters/eastwood.clj
@@ -32,8 +32,8 @@
     (->> @reports
          :warnings
          (map :warn-data)
-         (remove (fn [{{{[[_fn* [_arglist [_assert v]]]] :form} :ast} :wrong-pre-post}]
-                   (= "*" ;; False positives for dynamic vars https://git.io/fhQTx
+         (remove (fn [{{{[_fn* [_arglist [_assert v]]] :form} :ast} :wrong-pre-post}]
+                   (= \* ;; False positives for dynamic vars https://git.io/fhQTx
                       (-> v str first)
                       (-> v str last))))
          (map (fn [{:keys [uri-or-file-name linter] :as m}]

--- a/src/formatting_stack/linters/eastwood.clj
+++ b/src/formatting_stack/linters/eastwood.clj
@@ -32,7 +32,7 @@
     (->> @reports
          :warnings
          (map :warn-data)
-         (remove impl/wrong-pre-post-false-positives)
+         (remove impl/contains-dynamic-assertions?)
          (map (fn [{:keys [uri-or-file-name linter] :as m}]
                 (assoc m
                        :level    :warning

--- a/src/formatting_stack/linters/eastwood.clj
+++ b/src/formatting_stack/linters/eastwood.clj
@@ -32,11 +32,7 @@
     (->> @reports
          :warnings
          (map :warn-data)
-         (remove (fn [{{{[_fn* [_arglist [_assert v]]] :form} :ast} :wrong-pre-post}]
-                   (let [varname (-> v str (str/split #"\/") last)]
-                     (= \* ;; False positives for dynamic vars https://git.io/fhQTx
-                        (first varname)
-                        (last varname)))))
+         (remove impl/wrong-pre-post-false-positives)
          (map (fn [{:keys [uri-or-file-name linter] :as m}]
                 (assoc m
                        :level    :warning

--- a/src/formatting_stack/linters/eastwood.clj
+++ b/src/formatting_stack/linters/eastwood.clj
@@ -33,9 +33,10 @@
          :warnings
          (map :warn-data)
          (remove (fn [{{{[_fn* [_arglist [_assert v]]] :form} :ast} :wrong-pre-post}]
-                   (= \* ;; False positives for dynamic vars https://git.io/fhQTx
-                      (-> v str first)
-                      (-> v str last))))
+                   (let [varname (-> v str (str/split #"\/") last)]
+                     (= \* ;; False positives for dynamic vars https://git.io/fhQTx
+                        (first varname)
+                        (last varname)))))
          (map (fn [{:keys [uri-or-file-name linter] :as m}]
                 (assoc m
                        :level    :warning

--- a/src/formatting_stack/linters/eastwood/impl.clj
+++ b/src/formatting_stack/linters/eastwood/impl.clj
@@ -6,22 +6,24 @@
    [nedap.speced.def :as speced]))
 
 (speced/defn ^boolean? contains-dynamic-assertions?
-  "Does this linting result refer to a :pre/:post containing dynamic assetions?
+  "Does this linting result refer to a :pre/:post containing dynamic assertions?
 
 See https://git.io/fhQTx"
   [{{{[_fn* [_arglist & fn-tails]] :form} :ast} :wrong-pre-post
-    msg :msg :as x}]
+    msg                                         :msg
+    :as                                         x}]
   (->> fn-tails
        (some (fn [tail]
                (when (and (coll? tail)
                           (= 'clojure.core/assert
                              (first tail)))
-                 (let [v (second tail)]
+                 (let [v (second tail)
+                       v-name (name v)]
                    (and (symbol? v)
-                        (string/includes? msg (name v)) ;; make sure it's the same symbol as in msg
+                        (string/includes? msg v-name) ;; make sure it's the same symbol as in msg
                         (= \*
-                           (first (name v))
-                           (last (name v))))))))
+                           (first v-name)
+                           (last v-name)))))))
        (boolean)))
 
 (speced/defn ^::protocols.spec/reports warnings->reports

--- a/src/formatting_stack/linters/eastwood/impl.clj
+++ b/src/formatting_stack/linters/eastwood/impl.clj
@@ -18,10 +18,10 @@ See https://git.io/fhQTx"
                              (first tail)))
                  (let [v (second tail)]
                    (and (symbol? v)
-                     (string/includes? msg (name v)) ;; make sure it's the same symbol as in msg
-                     (= \*
-                        (first (name v))
-                        (last (name v))))))))
+                        (string/includes? msg (name v)) ;; make sure it's the same symbol as in msg
+                        (= \*
+                           (first (name v))
+                           (last (name v))))))))
        (boolean)))
 
 (speced/defn ^::protocols.spec/reports warnings->reports

--- a/src/formatting_stack/linters/eastwood/impl.clj
+++ b/src/formatting_stack/linters/eastwood/impl.clj
@@ -5,13 +5,18 @@
    [formatting-stack.protocols.spec :as protocols.spec]
    [nedap.speced.def :as speced]))
 
-(speced/defn ^boolean? wrong-pre-post-false-positives
-  "Removes false positives for dynamic vars https://git.io/fhQTx"
-  [{{{[_fn* [_arglist [_assert v]]] :form} :ast} :wrong-pre-post}]
-  (let [varname (-> v str (string/split #"\/") last)]
-    (= \*
-       (first varname)
-       (last varname))))
+(speced/defn ^boolean? contains-dynamic-assertions?
+  "Does this linting result refer to a :pre/:post containing dynamic assetions?
+
+See https://git.io/fhQTx"
+  [{{{[_fn* [_arglist [_assert & vs]]] :form} :ast} :wrong-pre-post}]
+  (->> vs
+       (some (fn [v]
+               (let [varname (-> v str (string/split #"\/") last)]
+                 (= \*
+                    (first varname)
+                    (last varname)))))
+       (boolean)))
 
 (speced/defn ^::protocols.spec/reports warnings->reports
   [^string? warnings]

--- a/src/formatting_stack/linters/eastwood/impl.clj
+++ b/src/formatting_stack/linters/eastwood/impl.clj
@@ -18,8 +18,9 @@ See https://git.io/fhQTx"
                           (= 'clojure.core/assert
                              (first tail)))
                  (let [v (second tail)
-                       v-name (name v)]
-                   (and (symbol? v)
+                       v-name (when (symbol? v)
+                                (name v))]
+                   (and v-name
                         (string/includes? msg v-name) ;; make sure it's the same symbol as in msg
                         (= \*
                            (first v-name)

--- a/src/formatting_stack/linters/eastwood/impl.clj
+++ b/src/formatting_stack/linters/eastwood/impl.clj
@@ -8,9 +8,6 @@
 (speced/defn ^boolean? wrong-pre-post-false-positives
   "Removes false positives for dynamic vars https://git.io/fhQTx"
   [{{{[_fn* [_arglist [_assert v]]] :form} :ast} :wrong-pre-post}]
-  (println ::fn _fn*)
-  (println ::a _assert)
-  (println ::v v)
   (let [varname (-> v str (string/split #"\/") last)]
     (= \*
        (first varname)

--- a/src/formatting_stack/linters/eastwood/impl.clj
+++ b/src/formatting_stack/linters/eastwood/impl.clj
@@ -1,8 +1,20 @@
 (ns formatting-stack.linters.eastwood.impl
   (:require
+   [clojure.string :as string]
    [eastwood.reporting-callbacks :as reporting-callbacks]
    [formatting-stack.protocols.spec :as protocols.spec]
    [nedap.speced.def :as speced]))
+
+(speced/defn ^boolean? wrong-pre-post-false-positives
+  "Removes false positives for dynamic vars https://git.io/fhQTx"
+  [{{{[_fn* [_arglist [_assert v]]] :form} :ast} :wrong-pre-post}]
+  (println ::fn _fn*)
+  (println ::a _assert)
+  (println ::v v)
+  (let [varname (-> v str (string/split #"\/") last)]
+    (= \*
+       (first varname)
+       (last varname))))
 
 (speced/defn ^::protocols.spec/reports warnings->reports
   [^string? warnings]

--- a/test-resources/eastwood_warning.clj
+++ b/test-resources/eastwood_warning.clj
@@ -26,3 +26,9 @@
   "This function should not return a prepost warning (because there's no precondition at all: the {:pre} is the return value)"
   [x]
   {:pre [x *dynamic*]})
+
+(defn no-pre-post-warning--4
+  "This function should return no prepost warnings."
+  [x]
+  {:pre [x *dynamic*]} ;; variation: *dynamic* is not the first member
+  logical-false)

--- a/test-resources/eastwood_warning.clj
+++ b/test-resources/eastwood_warning.clj
@@ -5,3 +5,8 @@
 (def reflection-warning
   (letfn [(get-path [x] (.getPath x))]
     (get-path (java.io.File. "a.clj"))))
+
+(def ^:dynamic *dynamic*)
+(defn no-pre-post-warning [x]
+  {:pre [*dynamic*]}
+  x)

--- a/test-resources/eastwood_warning.clj
+++ b/test-resources/eastwood_warning.clj
@@ -14,11 +14,13 @@
   {:pre [*dynamic*]}
   x)
 
+(def logical-false false)
+
 (defn no-pre-post-warning--2
-  "This function should not return a prepost warning (because the postcondition is dynamic)"
+  "This function should return 1 prepost warning about `#'logical-false` (because the postcondition is dynamic)"
   []
-  {:pre [x *dynamic*]} ;; variation: *dynamic* is not the first member
-  x)
+  {:pre [logical-false *dynamic*]} ;; variation: *dynamic* is not the first member
+  logical-false)
 
 (defn no-pre-post-warning--3
   "This function should not return a prepost warning (because there's no precondition at all: the {:pre} is the return value)"

--- a/test-resources/eastwood_warning.clj
+++ b/test-resources/eastwood_warning.clj
@@ -7,6 +7,20 @@
     (get-path (java.io.File. "a.clj"))))
 
 (def ^:dynamic *dynamic*)
-(defn no-pre-post-warning [x]
+
+(defn no-pre-post-warning--1
+  "This function should not return a prepost warning (because the precondition is dynamic)"
+  [x]
   {:pre [*dynamic*]}
   x)
+
+(defn no-pre-post-warning--2
+  "This function should not return a prepost warning (because the postcondition is dynamic)"
+  []
+  {:pre [x *dynamic*]} ;; variation: *dynamic* is not the first member
+  x)
+
+(defn no-pre-post-warning--3
+  "This function should not return a prepost warning (because there's no precondition at all: the {:pre} is the return value)"
+  [x]
+  {:pre [x *dynamic*]})

--- a/test/functional/formatting_stack/linters/eastwood.clj
+++ b/test/functional/formatting_stack/linters/eastwood.clj
@@ -28,4 +28,8 @@
         {:source   :eastwood/def-in-def
          :line     3
          :column   13
+         :filename "test-resources/eastwood_warning.clj"}
+        {:source   :eastwood/wrong-pre-post
+         :line     22
+         :column   9
          :filename "test-resources/eastwood_warning.clj"}]))))

--- a/test/functional/formatting_stack/linters/eastwood.clj
+++ b/test/functional/formatting_stack/linters/eastwood.clj
@@ -1,10 +1,15 @@
 (ns functional.formatting-stack.linters.eastwood
   (:require
-   [clojure.test :refer [are deftest]]
+   [clojure.test :refer [are deftest use-fixtures]]
    [formatting-stack.linters.eastwood :as sut]
    [formatting-stack.protocols.linter :as linter]
    [matcher-combinators.matchers :as matchers]
    [matcher-combinators.test :refer [match?]]))
+
+(use-fixtures :once (fn [tests]
+                      ;; prevent humongous AST representations from being printed:
+                      (binding [*print-level* 5]
+                        (tests))))
 
 (deftest lint!
   (let [linter (sut/new {})]
@@ -15,10 +20,10 @@
 
       "test-resources/eastwood_warning.clj"
       (matchers/in-any-order
-       [{:source :eastwood/warn-on-reflection
-         :msg "reference to field getPath can't be resolved"
-         :line 6
-         :column 25
+       [{:source   :eastwood/warn-on-reflection
+         :msg      "reference to field getPath can't be resolved"
+         :line     6
+         :column   25
          :filename "test-resources/eastwood_warning.clj"}
         {:source   :eastwood/def-in-def
          :line     3

--- a/test/unit/formatting_stack/linters/eastwood/impl.clj
+++ b/test/unit/formatting_stack/linters/eastwood/impl.clj
@@ -10,23 +10,35 @@
     (are [form expected] (testing (pr-str form)
                            (is (= expected
                                   (sut/contains-dynamic-assertions?
-                                   {:wrong-pre-post {:ast {:form (list 'fn* (list [] form))}}})))
+                                   {:wrong-pre-post {:ast {:form form}}
+                                    :msg (str "Precondition found that is probably always logical true or always logical false."
+                                              "Should be changed to function call?  *test*")})))
                            true)
-      (list 'clojure.core/assert '*test*)                     true
-      (list 'clojure.core/assert 'namespace/*test*)           true
+      (list 'fn* (list [] (list 'clojure.core/assert '*test*)))           true
 
-      (list 'clojure.core/assert '(foo 42) '*test*)           true
-      (list 'clojure.core/assert '(foo 42) 'namespace/*test*) true
+      (list 'fn* (list [] (list 'clojure.core/assert 'namespace/*test*))) true
 
-      (list 'clojure.core/assert 'test)                       false
-      (list 'clojure.core/assert '*namespace*/test)           false
-      (list 'clojure.core/assert '*namespace/test*)           false
+      (list 'fn*
+        (list []
+          (list 'clojure.core/assert '(foo 42))
+          (list 'clojure.core/assert '*test*)))                           true
 
-      (list 'clojure.core/assert 1)                           false
-      (list 'clojure.core/assert [])                          false
-      (list 'clojure.core/assert {})                          false
-      (list 'clojure.core/assert "test")                      false
-      (list 'clojure.core/assert "foo/test")                  false))
+      (list 'fn*
+        (list []
+          (list 'clojure.core/assert '(foo 42))
+          (list 'clojure.core/assert 'namespace/*test*)))                 true
+
+      (list 'fn* (list [] (list 'clojure.core/assert 'test)))             false
+
+      (list 'fn* (list [] (list 'clojure.core/assert '*namespace*/test))) false
+
+      (list 'fn* (list [] (list 'clojure.core/assert '*namespace/test*))) false
+
+      (list 'fn* (list [] (list 'clojure.core/assert 1)))                 false
+      (list 'fn* (list [] (list 'clojure.core/assert [])))                false
+      (list 'fn* (list [] (list 'clojure.core/assert {})))                false
+      (list 'fn* (list [] (list 'clojure.core/assert "test")))            false
+      (list 'fn* (list [] (list 'clojure.core/assert "foo/test")))        false)))
 
   (testing "can handle variable input"
     (are [input] (= false
@@ -36,7 +48,9 @@
       {:test 1}
       {:wrong-pre-post {:ast nil}}
       {:wrong-pre-post {:ast {:form []}}}
-      {:wrong-pre-post {:ast {:form '(fn* ([] (clojure.core/assert (true? true))))}}})))
+      {:wrong-pre-post {:ast {:form '(fn* ([] (clojure.core/assert (true? true))))}}}))
+
+#_ (clojure.test/run-tests)
 
 (deftest warnings->report
   (are [input expected] (match? expected

--- a/test/unit/formatting_stack/linters/eastwood/impl.clj
+++ b/test/unit/formatting_stack/linters/eastwood/impl.clj
@@ -19,14 +19,14 @@
       (list 'fn* (list [] (list 'clojure.core/assert 'namespace/*test*))) true
 
       (list 'fn*
-        (list []
-          (list 'clojure.core/assert '(foo 42))
-          (list 'clojure.core/assert '*test*)))                           true
+            (list []
+                  (list 'clojure.core/assert '(foo 42))
+                  (list 'clojure.core/assert '*test*)))                   true
 
       (list 'fn*
-        (list []
-          (list 'clojure.core/assert '(foo 42))
-          (list 'clojure.core/assert 'namespace/*test*)))                 true
+            (list []
+                  (list 'clojure.core/assert '(foo 42))
+                  (list 'clojure.core/assert 'namespace/*test*)))         true
 
       (list 'fn* (list [] (list 'clojure.core/assert 'test)))             false
 

--- a/test/unit/formatting_stack/linters/eastwood/impl.clj
+++ b/test/unit/formatting_stack/linters/eastwood/impl.clj
@@ -38,7 +38,7 @@
       (list 'fn* (list [] (list 'clojure.core/assert [])))                false
       (list 'fn* (list [] (list 'clojure.core/assert {})))                false
       (list 'fn* (list [] (list 'clojure.core/assert "test")))            false
-      (list 'fn* (list [] (list 'clojure.core/assert "foo/test")))        false)))
+      (list 'fn* (list [] (list 'clojure.core/assert "foo/test")))        false))
 
   (testing "can handle variable input"
     (are [input] (= false
@@ -48,9 +48,7 @@
       {:test 1}
       {:wrong-pre-post {:ast nil}}
       {:wrong-pre-post {:ast {:form []}}}
-      {:wrong-pre-post {:ast {:form '(fn* ([] (clojure.core/assert (true? true))))}}}))
-
-#_ (clojure.test/run-tests)
+      {:wrong-pre-post {:ast {:form '(fn* ([] (clojure.core/assert (true? true))))}}})))
 
 (deftest warnings->report
   (are [input expected] (match? expected


### PR DESCRIPTION
## Brief

running eatwood over a form like `(defn x [y] {:pre [*dyn*]} y)` resulted in `java.lang.UnsupportedOperationException: nth not supported on this type: Symbol`

Added a testcase for this issue
<!-- Which issue does this PR fix? Ideally, create an issue if there was none, so the problem in question is well stated. -->

## QA plan

Remove the `remove`-fn from `formatting-stack/linters/eastwood.clj:35`, rerun tests. it triggers on the `:wrong-pre-post`

<!-- Please state a reproducible plan to prove this PR works. Attach screenshots, gifs, etc. if needed. Occasionally, sufficient test coverage removes the need for QAing. -->

## Author checklist

<!-- Please, before publicizing your PR, open it as a "WIP PR", and then review it using the following. -->

* [x] I have QAed the functionality
* [x] The PR has a reasonably reviewable size and a meaningful commit history
* [x] I have run the [branch formatter](https://github.com/nedap/formatting-stack/blob/332a419034ab46fad526a5592f4257353bd695b6/src/formatting_stack/branch_formatter.clj) and observed no new/significative warnings
* [x] The build passes
* [x] I have self-reviewed the PR prior to assignment
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [x] Correctness
  * [x] Robustness (red paths, failure handling etc)
  * [ ] Modular design
  * [x] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
  * [ ] Cross-compatibility (Clojure/ClojureScript)

## Reviewer checklist

* [x] I have checked out this branch and reviewed it locally, running it
* [x] I have QAed the functionality
* [x] I have reviewed the PR
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [x] Correctness
  * [x] Robustness (red paths, failure handling etc)
  * [ ] Modular design
  * [x] Test coverage
  * [x] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
  * [x] Cross-compatibility (Clojure/ClojureScript)
