### PR TITLE
Introduce `strategies.impl/absolutize`

### DIFF
--- a/src/formatting_stack/strategies/impl.clj
+++ b/src/formatting_stack/strategies/impl.clj
@@ -49,7 +49,9 @@
          (map (fn [filename]
                 (->> (string/split filename separator-pattern)
                      (concat toplevel-fragments)
-                     (string/join File/separator)))))))
+                     (string/join File/separator)
+                     File.
+                     .getCanonicalPath))))))
 
 (def ^:dynamic *filter-existing-files?* true)
 

--- a/test/integration/formatting_stack/strategies/impl.clj
+++ b/test/integration/formatting_stack/strategies/impl.clj
@@ -1,6 +1,6 @@
 (ns integration.formatting-stack.strategies.impl
   (:require
-   [clojure.test :refer [are deftest]]
+   [clojure.test :refer [are deftest is]]
    [formatting-stack.strategies.impl :as sut])
   (:import
    (java.io File)))
@@ -23,3 +23,10 @@
     "."                             (File. "I_dont_exist")                                false
     "dev"                           (File. "I_dont_exist")                                false
     "dev"                           (File. "user.clj")                                    false))
+
+(deftest absolutize
+  (let [target "src/formatting_stack/strategies/impl.clj"]
+    (is (= (sut/absolutize "git" [target])
+           [(-> target File. .getCanonicalPath)]))
+
+    (is (spec-assertion-thrown? ::sut/existing-files (sut/absolutize "git" ["I_dont_exist"])))))

--- a/test/integration/formatting_stack/strategies/impl.clj
+++ b/test/integration/formatting_stack/strategies/impl.clj
@@ -1,6 +1,6 @@
 (ns integration.formatting-stack.strategies.impl
   (:require
-   [clojure.test :refer [are deftest is]]
+   [clojure.test :refer [are deftest is testing]]
    [formatting-stack.strategies.impl :as sut])
   (:import
    (java.io File)))
@@ -25,8 +25,11 @@
     "dev"                           (File. "user.clj")                                    false))
 
 (deftest absolutize
-  (let [target "src/formatting_stack/strategies/impl.clj"]
-    (is (= (sut/absolutize "git" [target])
-           [(-> target File. .getCanonicalPath)]))
+  (are [target] (testing target
+                  (is (= [(-> target File. .getCanonicalPath)]
+                         (sut/absolutize "git" [target])))
+                  true)
+    "src/formatting_stack/strategies/impl.clj"
+    "src/../src/formatting_stack/strategies/impl.clj")
 
-    (is (spec-assertion-thrown? ::sut/existing-files (sut/absolutize "git" ["I_dont_exist"])))))
+  (is (spec-assertion-thrown? ::sut/existing-files (sut/absolutize "git" ["I_dont_exist"]))))

--- a/test/unit/formatting_stack/strategies.clj
+++ b/test/unit/formatting_stack/strategies.clj
@@ -6,7 +6,8 @@
    [formatting-stack.strategies.impl :as sut.impl]))
 
 (use-fixtures :once (fn [tests]
-                      (binding [sut.impl/*filter-existing-files?* false]
+                      (binding [sut.impl/*filter-existing-files?* false
+                                sut.impl/*skip-existing-files-check?* true]
                         (tests))))
 
 (def not-completely-staged-files
@@ -29,7 +30,9 @@
             (-> s
                 (str/replace #".* " "")
                 (str/replace "test/unit/formatting_stack/g.clj -> " "")))]
-    (map strip files)))
+    (->> files
+         (map strip)
+         (sut.impl/absolutize "git"))))
 
 (deftest git-completely-staged
   (is (= (strip-git completely-staged-files)
@@ -40,7 +43,7 @@
          (sut/git-not-completely-staged :files [] :impl all-files))))
 
 (deftest git-diff-against-default-branch
-  (is (= ["a.clj"]
+  (is (= (sut.impl/absolutize "git" ["a.clj"])
          (sut/git-diff-against-default-branch :files []
                                               :impl ["a.clj" "b.clj"]
-                                              :blacklist ["b.clj"]))))
+                                              :blacklist (sut.impl/absolutize "git" ["b.clj"])))))


### PR DESCRIPTION
## Brief

Fixes nedap/formatting-stack#3

Between this PR and some existing functionality (like `strategies/namespaces-within-refresh-dirs-only`), f-s should now fit into any project layout.

## QA plan

### 1

Formatting/linting keeps working in:

* the staged area (`format!`)
* the current branch (`branch-formatter`)
* the whole project (`project-formatter`)

You can locally add silly changes to test that out.

### 2

Try out in a given monorepo.

## Author checklist

<!-- Please, before publicizing your PR, open it as a "WIP PR", and then review it using the following. -->

* [x] I have QAed the functionality
* [x] The PR has a reasonably reviewable size and a meaningful commit history
* [x] I have run the [branch formatter](https://github.com/nedap/formatting-stack/blob/332a419034ab46fad526a5592f4257353bd695b6/src/formatting_stack/branch_formatter.clj) and observed no new/significative warnings
* [x] The build passes
* [x] I have self-reviewed the PR prior to assignment
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [x] Correctness
  * [x] Robustness (red paths, failure handling etc)
  * [x] Modular design
  * [x] Test coverage
  * [x] Spec coverage
  * [x] Documentation
  * [x] Security
  * [x] Performance
  * [x] Breaking API changes
  * [x] Cross-compatibility (Clojure/ClojureScript)

## Reviewer checklist

* [ ] I have checked out this branch and reviewed it locally, running it
* [ ] I have QAed the functionality
* [ ] I have reviewed the PR
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [ ] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Modular design
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
  * [ ] Cross-compatibility (Clojure/ClojureScript)
