### PR TITLE
[#126] Add mount integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **formatting-stack** is a formatting/linting solution that can be integrated with:
 
-* your [Component](https://github.com/stuartsierra/component) (or [Integrant](https://github.com/weavejester/integrant), or bare [tools.namespace](https://github.com/clojure/tools.namespace)) system
+* your [Component](https://github.com/stuartsierra/component) (or [Integrant](https://github.com/weavejester/integrant), or [mount](https://github.com/tolitius/mount), or bare [tools.namespace](https://github.com/clojure/tools.namespace)) system
   * for instantaneous performance
     * no cold-starts!
   * and precise understanding of your codebase
@@ -95,11 +95,11 @@ As you can see in the screenshot, **formatting-stack** presents linters' outputs
   * Else, please add the latest version to your project (or personal [profile](https://github.com/technomancy/leiningen/blob/072dcd62dea0ea46413cf938878e2d31b76357c9/doc/PROFILES.md)).
   * If this dependency isn't added, formatting-stack will degrade gracefully, using slightly fewer formatters/linters.
 
-### Component/Integrant integration
+### Component/Integrant/mount integration
 
 **formatting-stack** provides components that you can integrate into your system.
 
-The provided components are fully configurable. See `formatting-stack.core`, `formatting-stack.component`, `formatting-stack.integrant`.
+The provided components are fully configurable. See `formatting-stack.core`, `formatting-stack.component`, `formatting-stack.integrant`, `formatting-stack.mount`.
 
 ### Reloaded Workflow integration
 
@@ -107,6 +107,8 @@ The provided components are fully configurable. See `formatting-stack.core`, `fo
   * You can find a working sample setup in [component_repl.clj](https://github.com/nedap/formatting-stack/blob/master/test-resources/component_repl.clj).
 * If you use the Integrant component, then `integrant.repl/reset` will use formatting-stack, applying all its formatters/linters.
   * You can find a working sample setup in [integrant_repl.clj](https://github.com/nedap/formatting-stack/blob/master/test-resources/integrant_repl.clj).
+* If you use the mount component, then `mount.core/start` will use formatting-stack, applying all its formatters/linters.
+  * You can find a working sample setup in [mount_repl.clj](https://github.com/nedap/formatting-stack/blob/master/test-resources/mount_repl.clj).
 
 The above can be good enough. However `reset`ting your system can be somewhat expensive,
 and you may find yourself using `clojure.tools.namespace.repl/refresh` instead.

--- a/project.clj
+++ b/project.clj
@@ -66,9 +66,11 @@
                                              [criterium "0.4.5"]
                                              [integrant/repl "0.3.1"]
                                              [lambdaisland/deep-diff "0.0-29"]
+                                             [mount "0.1.16"]
                                              [org.clojure/core.async "0.5.527"]
                                              [org.clojure/math.combinatorics "0.1.1"]
-                                             [org.clojure/test.check "0.10.0-alpha3"]]
+                                             [org.clojure/test.check "0.10.0-alpha3"]
+                                             [tolitius/mount-up "0.1.2"]]
                               :jvm-opts     ["-Dclojure.compiler.disable-locals-clearing=true"]
                               :source-paths ["dev"]
                               :repl-options {:init-ns dev}
@@ -101,7 +103,9 @@
                                              [com.google.errorprone/error_prone_annotations "2.1.3" #_"transitive"]
                                              [com.google.code.findbugs/jsr305 "3.0.2" #_"transitive"]
                                              [com.stuartsierra/component "0.4.0"]
-                                             [integrant "0.8.0"]]}
+                                             [integrant "0.8.0"]
+                                             [mount "0.1.16"]
+                                             [tolitius/mount-up "0.1.2"]]}
 
              ;; `dev` in :test is important - a test depends on it:
              :test           {:source-paths   ["dev"]

--- a/src/formatting_stack/mount.clj
+++ b/src/formatting_stack/mount.clj
@@ -1,0 +1,26 @@
+(ns formatting-stack.mount
+  (:require
+   [formatting-stack.component.impl :refer [parse-options]]
+   [formatting-stack.core :refer [format!]]
+   [mount.core :as mount]
+   [mount-up.core :as mount-up]
+   [nedap.speced.def :as speced]))
+
+(speced/defn start [^map? this]
+  (->> this
+       parse-options
+       (apply format!))
+  this)
+
+;; Allow parameterless configuring using `mount/start-with-args`.
+(mount-up/on-up :formatting-with-mount-args
+                (fn [_]
+                  (when-let [config (::config (mount/args))]
+                    (start config)))
+                :before)
+
+(defn configure [config]
+  (mount-up/on-up :formatting-with-provided-config
+                  (fn [_]
+                    (start config))
+                  :before))

--- a/test-resources/mount_repl.clj
+++ b/test-resources/mount_repl.clj
@@ -1,0 +1,23 @@
+(ns mount-repl
+  "Documents a working setup for mount.
+
+  Not a part of the test suite."
+  (:require [formatting-stack.mount]
+            [mount.core]))
+
+(def sample-linters
+  [(reify formatting-stack.protocols.linter/Linter
+     (--lint! [this filenames]
+       [{:source   ::my-linter
+         :level    :warning
+         :column   40
+         :line     6
+         :msg      "Hello, I am a sample linter!"
+         :filename "path.clj"}]))])
+
+(formatting-stack.mount/configure! {:linters sample-linters})
+
+(comment
+  (mount.core/start)
+  (mount.core/start-with-args
+   {:formatting-stack.mount/config {:linters sample-linters}}))

--- a/test/functional/formatting_stack/mount.clj
+++ b/test/functional/formatting_stack/mount.clj
@@ -1,0 +1,60 @@
+(ns functional.formatting-stack.mount
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [formatting-stack.mount :as sut]
+   [formatting-stack.reporters.passthrough :as reporters.passthrough]
+   [mount.core :as mount :refer [defstate]]
+   [nedap.utils.spec.api :refer [check!]]))
+
+(def sample-report
+  {:source   ::some-linter
+   :level    :warning
+   :column   40
+   :line     1
+   :msg      "omg"
+   :filename "foo.clj"})
+
+(defn proof [a]
+  (reify formatting-stack.protocols.linter/Linter
+    (--lint! [this filenames]
+      (check! empty? filenames)
+      (reset! a [sample-report]))))
+
+(defstate stateful-component
+  :start 42
+  :stop 0)
+
+(deftest works
+  (testing "It can be started/stopped without errors"
+    (let [p (atom nil)
+          ;; pass an empty stack (except for the `proof`), so that no side-effects will be triggered (would muddy the test suite):
+          opts {:strategies               []
+                :third-party-indent-specs {}
+                :formatters               []
+                :linters                  [(proof p)]
+                :processors               []
+                :in-background?           false
+                :reporter                 (reporters.passthrough/new)}]
+      (sut/configure opts)
+      (mount/start)
+      (testing "It actually runs its members, such as linters"
+        (is (= [sample-report]
+               @p)))
+      (mount/stop))))
+
+(deftest works-with-mount-args
+  (testing "It can be started/stopped without errors"
+    (let [p (atom nil)
+          ;; pass an empty stack (except for the `proof`), so that no side-effects will be triggered (would muddy the test suite):
+          opts {:strategies               []
+                :third-party-indent-specs {}
+                :formatters               []
+                :linters                  [(proof p)]
+                :processors               []
+                :in-background?           false
+                :reporter                 (reporters.passthrough/new)}]
+      (mount/start-with-args {:formatting-stack.mount/config opts})
+      (testing "It actually runs its members, such as linters"
+        (is (= [sample-report]
+               @p)))
+      (mount/stop))))


### PR DESCRIPTION
- Add new `formatting-stack.mount` namespace for configuring `on-up`
  hooks
- Add mount tests and example repl/dev implementation

## Brief

#126 

## QA plan

Green tests

## Author checklist

* [x] I have QAed the functionality
* [x] The PR has a reasonably reviewable size and a meaningful commit history
* [ ] I have run the [branch formatter](https://github.com/nedap/formatting-stack/blob/332a419034ab46fad526a5592f4257353bd695b6/src/formatting_stack/branch_formatter.clj) and observed no new/significative warnings
* [ ] The build passes
* [x] I have self-reviewed the PR prior to assignment
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [x] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Modular design
  * [x] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
  * [ ] Cross-compatibility (Clojure/ClojureScript)

## Reviewer checklist

* [ ] I have checked out this branch and reviewed it locally, running it
* [ ] I have QAed the functionality
* [ ] I have reviewed the PR
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [ ] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Modular design
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
  * [ ] Cross-compatibility (Clojure/ClojureScript)
