### PR TITLE
`eastwood.impl`: use safer destructuring

### DIFF
--- a/src/formatting_stack/linters/eastwood/impl.clj
+++ b/src/formatting_stack/linters/eastwood/impl.clj
@@ -9,21 +9,20 @@
   "Does this linting result refer to a :pre/:post containing dynamic assertions?
 
 See https://git.io/fhQTx"
-  [{{{xxx :form} :ast} :wrong-pre-post
-    msg                :msg
-    :as                x}]
-  (let [[_fn* yyy] (if (coll? xxx)
-                     xxx
-                     [])
-        [_arglist & fn-tails] (if (coll? yyy)
-                                yyy
-                                [])]
-    (->> fn-tails
-         (some (fn [tail]
-                 (when (and (coll? tail)
+  [{{{ast-form :form} :ast} :wrong-pre-post
+    msg                     :msg}]
+  (let [[_fn* fn-tails] (if (coll? ast-form)
+                          ast-form
+                          [])
+        [_arglist & body] (if (coll? fn-tails)
+                            fn-tails
+                            [])]
+    (->> body
+         (some (fn [form]
+                 (when (and (coll? form)
                             (= 'clojure.core/assert
-                               (first tail)))
-                   (let [v (second tail)
+                               (first form)))
+                   (let [v      (second form)
                          v-name (when (symbol? v)
                                   (name v))]
                      (and v-name

--- a/src/formatting_stack/linters/eastwood/impl.clj
+++ b/src/formatting_stack/linters/eastwood/impl.clj
@@ -9,23 +9,29 @@
   "Does this linting result refer to a :pre/:post containing dynamic assertions?
 
 See https://git.io/fhQTx"
-  [{{{[_fn* [_arglist & fn-tails]] :form} :ast} :wrong-pre-post
-    msg                                         :msg
-    :as                                         x}]
-  (->> fn-tails
-       (some (fn [tail]
-               (when (and (coll? tail)
-                          (= 'clojure.core/assert
-                             (first tail)))
-                 (let [v (second tail)
-                       v-name (when (symbol? v)
-                                (name v))]
-                   (and v-name
-                        (string/includes? msg v-name) ;; make sure it's the same symbol as in msg
-                        (= \*
-                           (first v-name)
-                           (last v-name)))))))
-       (boolean)))
+  [{{{xxx :form} :ast} :wrong-pre-post
+    msg                :msg
+    :as                x}]
+  (let [[_fn* yyy] (if (coll? xxx)
+                     xxx
+                     [])
+        [_arglist & fn-tails] (if (coll? yyy)
+                                yyy
+                                [])]
+    (->> fn-tails
+         (some (fn [tail]
+                 (when (and (coll? tail)
+                            (= 'clojure.core/assert
+                               (first tail)))
+                   (let [v (second tail)
+                         v-name (when (symbol? v)
+                                  (name v))]
+                     (and v-name
+                          (string/includes? msg v-name) ;; make sure it's the same symbol as in msg
+                          (= \*
+                             (first v-name)
+                             (last v-name)))))))
+         (boolean))))
 
 (speced/defn ^::protocols.spec/reports warnings->reports
   [^string? warnings]

--- a/test/unit/formatting_stack/linters/eastwood/impl.clj
+++ b/test/unit/formatting_stack/linters/eastwood/impl.clj
@@ -28,6 +28,16 @@
                   (list 'clojure.core/assert '(foo 42))
                   (list 'clojure.core/assert 'namespace/*test*)))         true
 
+      nil                                                                 false
+      []                                                                  false
+      42                                                                  false
+      [42]                                                                false
+      [[42]]                                                              false
+      [[[42]]]                                                            false
+      [:_ [:_]]                                                           false
+      [:_ [:_ []]]                                                        false
+      [:_ [:_ 'aaaaaaaaa]]                                                false
+
       (list 'fn* (list [] (list 'clojure.core/assert 'test)))             false
 
       (list 'fn* (list [] (list 'clojure.core/assert '*namespace*/test))) false


### PR DESCRIPTION
## Brief

Fixes an issue found in a private project.

## QA plan

* Tests added - the only pass w/ the provided fix
* Screenshots passed privately proving the fix.

## Author checklist

<!-- Please, before publicizing your PR, open it as a "WIP PR", and then review it using the following. -->

* [x] I have QAed the functionality
* [x] The PR has a reasonably reviewable size and a meaningful commit history
* [x] I have run the [branch formatter](https://github.com/nedap/formatting-stack/blob/332a419034ab46fad526a5592f4257353bd695b6/src/formatting_stack/branch_formatter.clj) and observed no new/significative warnings
* [x] The build passes
* [x] I have self-reviewed the PR prior to assignment
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [x] Correctness
  * [x] Robustness (red paths, failure handling etc)
  * [x] Modular design
  * [x] Test coverage
  * [x] Spec coverage
  * [x] Documentation
  * [x] Security
  * [x] Performance
  * [x] Breaking API changes
  * [x] Cross-compatibility (Clojure/ClojureScript)

## Reviewer checklist

* [ ] I have checked out this branch and reviewed it locally, running it
* [x] I have QAed the functionality
* [x] I have reviewed the PR
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [x] Correctness
  * [x] Robustness (red paths, failure handling etc)
  * [ ] Modular design
  * [x] Test coverage
  * [ ] Spec coverage
  * [x] Documentation
  * [ ] Security
  * [x] Performance
  * [x] Breaking API changes
  * [x] Cross-compatibility (Clojure/ClojureScript)
