### PR TITLE
v4.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ As you can see in the screenshot, **formatting-stack** presents linters' outputs
 #### Coordinates
 
 ```clojure
-[formatting-stack "3.2.0"]
+[formatting-stack "4.0.0"]
 ```
 
 **Also** you might have to add the [refactor-nrepl](https://github.com/clojure-emacs/refactor-nrepl) dependency.

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 ;; Please don't bump the library version by hand - use ci.release-workflow instead.
-(defproject formatting-stack "3.2.0"
+(defproject formatting-stack "4.0.0"
   ;; Please keep the dependencies sorted a-z.
   :dependencies [[clj-kondo "2020.01.13"]
                  [cljfmt "0.6.5" :exclusions [rewrite-clj]]


### PR DESCRIPTION
## Changelog

* #130 - We've made formatting-stack substantially easier to configure, documenting so.
* #131 - Eastwood bugfix

> The `:id` requirement is a **breaking change**, because a user that provided a map-based custom member would have to add an :id to have things working again.

## Release checklist (author)

* [x] All PRs / relevant commits since the previous release are listed in this PR's description 
* [x] The new proposed version follows semver 
* [x] The build passes
* [x] New features are (briefly) reflected in the README

## Release checklist (reviewer)

* [x] All PRs / relevant commits since the previous release are listed in this PR's description 
* [x] The new proposed version follows semver 
* [x] New features are (briefly) reflected in the README
