### PR TITLE
[#126] Remove mount/args support

### DIFF
--- a/src/formatting_stack/mount.clj
+++ b/src/formatting_stack/mount.clj
@@ -12,15 +12,5 @@
        (apply format!))
   this)
 
-;; Allow parameterless configuring using `mount/start-with-args`.
-(mount-up/on-up :formatting-with-mount-args
-                (fn [_]
-                  (when-let [config (::config (mount/args))]
-                    (start config)))
-                :before)
-
-(defn configure [config]
-  (mount-up/on-up :formatting-with-provided-config
-                  (fn [_]
-                    (start config))
-                  :before))
+(defn configure! [config]
+  (mount-up/on-up :formatting (fn [_] (start config)) :before))

--- a/test/functional/formatting_stack/mount.clj
+++ b/test/functional/formatting_stack/mount.clj
@@ -35,25 +35,8 @@
                 :processors               []
                 :in-background?           false
                 :reporter                 (reporters.passthrough/new)}]
-      (sut/configure opts)
+      (sut/configure! opts)
       (mount/start)
-      (testing "It actually runs its members, such as linters"
-        (is (= [sample-report]
-               @p)))
-      (mount/stop))))
-
-(deftest works-with-mount-args
-  (testing "It can be started/stopped without errors"
-    (let [p (atom nil)
-          ;; pass an empty stack (except for the `proof`), so that no side-effects will be triggered (would muddy the test suite):
-          opts {:strategies               []
-                :third-party-indent-specs {}
-                :formatters               []
-                :linters                  [(proof p)]
-                :processors               []
-                :in-background?           false
-                :reporter                 (reporters.passthrough/new)}]
-      (mount/start-with-args {:formatting-stack.mount/config opts})
       (testing "It actually runs its members, such as linters"
         (is (= [sample-report]
                @p)))


### PR DESCRIPTION
- While potentially handy in some cases, most often the dual (and
  independent) configuration's for mount can get confusing.

## QA plan

Green tests

## Author checklist

* [x] I have QAed the functionality
* [x] The PR has a reasonably reviewable size and a meaningful commit history
* [ ] I have run the [branch formatter](https://github.com/nedap/formatting-stack/blob/332a419034ab46fad526a5592f4257353bd695b6/src/formatting_stack/branch_formatter.clj) and observed no new/significative warnings
* [ ] The build passes
* [x] I have self-reviewed the PR prior to assignment
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [x] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Modular design
  * [x] Test coverage
  * [ ] Spec coverage
  * [x] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
  * [ ] Cross-compatibility (Clojure/ClojureScript)

## Reviewer checklist

* [ ] I have checked out this branch and reviewed it locally, running it
* [ ] I have QAed the functionality
* [ ] I have reviewed the PR
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [ ] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Modular design
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
  * [ ] Cross-compatibility (Clojure/ClojureScript)
