### PR TITLE
Upgrade utils.modular

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,6 +89,11 @@ workflows:
           lein_test_command: lein with-profile -dev,+ci do clean, test
           <<: *test_code_filters
       - test_code:
+          name: "JDK 8, with an old clojurescript dependency on the classpath"
+          jdk_version: openjdk8
+          lein_test_command: lein with-profile -dev,-provided,+ci,+cljs-old do clean, test
+          <<: *test_code_filters
+      - test_code:
           name: "JDK 11 including refactor-nrepl"
           jdk_version: openjdk11
           lein_test_command: lein with-profile -dev,+ci,+refactor-nrepl do clean, test
@@ -101,6 +106,7 @@ workflows:
       - deploy:
           context: JFrog
           requires:
+            - "JDK 8, with an old clojurescript dependency on the classpath"
             - "JDK 8 including refactor-nrepl"
             - "JDK 8 excluding refactor-nrepl"
             - "JDK 11 including refactor-nrepl"

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
                  [com.gfredericks/lein-all-my-files-should-end-with-exactly-one-newline-character "0.1.1"]
                  [com.nedap.staffing-solutions/speced.def "2.0.0"]
                  [com.nedap.staffing-solutions/utils.collections "2.0.0"]
-                 [com.nedap.staffing-solutions/utils.modular "2.1.0"]
+                 [com.nedap.staffing-solutions/utils.modular "2.2.0-alpha3"]
                  [com.nedap.staffing-solutions/utils.spec.predicates "1.1.0"]
                  [jonase/eastwood "0.3.5"]
                  [medley "1.2.0"]
@@ -90,6 +90,13 @@
                                                                                                            (exclusions (str dep))))
                                                                                                  vec))))))
                                                 'user/nedap-ensure-exclusions)]}
+
+             :cljs-old       {:dependencies [[com.stuartsierra/component "0.4.0"]
+                                             [integrant "0.8.0"]
+                                             [org.clojure/clojurescript "1.7.228"
+                                              :exclusions [com.cognitect/transit-clj
+                                                           com.google.code.findbugs/jsr305
+                                                           com.google.errorprone/error_prone_annotations]]]}
 
              :provided       {:dependencies [[org.clojure/clojurescript "1.10.597"
                                               :exclusions [com.cognitect/transit-clj


### PR DESCRIPTION
## Brief

Ensures formatting-stack works even when there's an overly old clojurescript dep on the classpath.

Delivers https://github.com/nedap/utils.modular/pull/18 

## QA plan

#### 1

* Revert the upgrade
* Locally, run the new CI command. It will fail.

#### 2

Verify https://github.com/nedap/utils.modular/pull/18  introduces no problematic changes

## Author checklist

<!-- Please, before publicizing your PR, open it as a "WIP PR", and then review it using the following. -->

* [x] I have QAed the functionality
* [x] The PR has a reasonably reviewable size and a meaningful commit history
* [ ] I have run the [branch formatter](https://github.com/nedap/formatting-stack/blob/332a419034ab46fad526a5592f4257353bd695b6/src/formatting_stack/branch_formatter.clj) and observed no new/significative warnings
* [x] The build passes
* [x] I have self-reviewed the PR prior to assignment
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [x] Correctness
  * [x] Robustness (red paths, failure handling etc)
  * [ ] Modular design
  * [x] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [x] Breaking API changes
  * [x] Cross-compatibility (Clojure/ClojureScript)

## Reviewer checklist

* [x] I have checked out this branch and reviewed it locally, running it
* [x] I have QAed the functionality
* [x] I have reviewed the PR
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [x] Correctness
  * [x] Robustness (red paths, failure handling etc)
  * [ ] Modular design
  * [x] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [x] Breaking API changes
  * [x] Cross-compatibility (Clojure/ClojureScript)
