### PR TITLE
v4.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ As you can see in the screenshot, **formatting-stack** presents linters' outputs
 #### Coordinates
 
 ```clojure
-[formatting-stack "4.0.0"]
+[formatting-stack "4.0.1"]
 ```
 
 **Also** you might have to add the [refactor-nrepl](https://github.com/clojure-emacs/refactor-nrepl) dependency.

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 ;; Please don't bump the library version by hand - use ci.release-workflow instead.
-(defproject formatting-stack "4.0.0"
+(defproject formatting-stack "4.0.1"
   ;; Please keep the dependencies sorted a-z.
   :dependencies [[clj-kondo "2020.01.13"]
                  [cljfmt "0.6.5" :exclusions [rewrite-clj]]


### PR DESCRIPTION
## Changelog

* https://github.com/nedap/formatting-stack/pull/136/ - no more possible errors on startup related to `org.clojure/clojurescript` (which formatting-stack does not depend on)
* https://github.com/nedap/formatting-stack/pull/137 - bugfixes related to handling Git deletions, as well as various Git ops in monorepo projects.
* https://github.com/nedap/formatting-stack/pull/138/ - ensure formatting-stack works with various combinations of refactor-nrepl, cider-nrepl, and the JDK.

## Release checklist (author)

* [x] All PRs / relevant commits since the previous release are listed in this PR's description 
* [x] The new proposed version follows semver 
* [x] The build passes
* [x] New features are (briefly) reflected in the README
  * (nothing to add)

## Release checklist (reviewer)

* [x] All PRs / relevant commits since the previous release are listed in this PR's description 
* [x] The new proposed version follows semver 
* [x] New features are (briefly) reflected in the README
