### PR TITLE
Reporters: introduce `normalize-filenames`

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -18,7 +18,7 @@
                  [rewrite-clj "0.6.1"]]
 
   ;; The f-s exclusion allows adding f-s in a global profile, while still allowing developing f-s itself,
-  ;; avoiding having the global version shadow the local onel
+  ;; avoiding having the global version shadow the local one
   :exclusions [formatting-stack]
 
   :description "An efficient, smart, graceful composition of formatters, linters and such."

--- a/src/formatting_stack/core.clj
+++ b/src/formatting_stack/core.clj
@@ -8,6 +8,7 @@
    [formatting-stack.protocols.linter :as protocols.linter]
    [formatting-stack.protocols.processor :as protocols.processor]
    [formatting-stack.protocols.reporter :refer [report]]
+   [formatting-stack.reporters.impl :refer [normalize-filenames]]
    [formatting-stack.reporters.pretty-printer :as reporters.pretty-printer]
    [formatting-stack.util :refer [with-serialized-output]]))
 
@@ -71,6 +72,7 @@
                      (process! protocols.linter/lint!       linters     linters-strategies    strategies)
                      (process! protocols.processor/process! processors  processors-strategies strategies)]
                     (apply concat)
+                    (mapv normalize-filenames)
                     (report reporter)))]
     (if in-background?
       (do

--- a/src/formatting_stack/linters/eastwood.clj
+++ b/src/formatting_stack/linters/eastwood.clj
@@ -2,7 +2,6 @@
   (:require
    [clojure.string :as str]
    [eastwood.lint]
-   [eastwood.util]
    [formatting-stack.linters.eastwood.impl :as impl]
    [formatting-stack.protocols.linter :as linter]
    [formatting-stack.util :refer [ns-name-from-filename]]
@@ -22,7 +21,6 @@
   (let [namespaces (->> filenames
                         (remove #(str/ends-with? % ".edn"))
                         (keep ns-name-from-filename))
-        root-dir   (-> (File. "") .getAbsolutePath)
         reports    (atom nil)
         output     (with-out-str
                      (binding [*warn-on-reflection* true]
@@ -38,9 +36,7 @@
                             :warning-details-url warning-details-url
                             :filename            (if (string? uri-or-file-name)
                                                    uri-or-file-name
-                                                   (str/replace (-> ^File uri-or-file-name .getPath)
-                                                                root-dir
-                                                                "")))))
+                                                   (-> ^File uri-or-file-name .getCanonicalPath)))))
          (concat (impl/warnings->reports output)))))
 
 (defn new [{:keys [eastwood-options]

--- a/src/formatting_stack/reporters/impl.clj
+++ b/src/formatting_stack/reporters/impl.clj
@@ -1,0 +1,12 @@
+(ns formatting-stack.reporters.impl
+  (:require
+   [clojure.string :as string]
+   [nedap.speced.def :as speced]))
+
+(speced/defn normalize-filenames
+  "Removes the CWD from the filenames, for more concise output, and also for ensuring correct grouping."
+  [{:keys [^string? filename] :as report}]
+  (assoc report :filename (-> filename
+                              (string/replace (re-pattern (str "^" (System/getProperty "user.dir")))
+                                              "")
+                              (string/replace #"^/" ""))))

--- a/test/unit/formatting_stack/reporters/impl.clj
+++ b/test/unit/formatting_stack/reporters/impl.clj
@@ -1,0 +1,16 @@
+(ns unit.formatting-stack.reporters.impl
+  (:require
+   [clojure.test :refer [are deftest is testing]]
+   [formatting-stack.reporters.impl :as sut]))
+
+(deftest normalize-filenames
+  (let [cwd (System/getProperty "user.dir")]
+    (are [input expected] (testing input
+                            (is (= {:filename expected}
+                                   (sut/normalize-filenames {:filename input})))
+                            true)
+      ""                      ""
+      "a"                     "a"
+      cwd                     ""
+      (str cwd "/a.clj")      "a.clj"
+      (str cwd "/a.clj" cwd), (str "a.clj" cwd))))


### PR DESCRIPTION
## Brief

This PR trims the CWD out of reporters' output, which was ugly and could affect grouping.

## QA plan

I have checked these changes by running `(lint-project)` in f-s itself, a monorepo and another large project.

Output is now trimmed and homogeneous.

## Author checklist

<!-- Please, before publicizing your PR, open it as a "WIP PR", and then review it using the following. -->

* [x] I have QAed the functionality
* [x] The PR has a reasonably reviewable size and a meaningful commit history
* [x] I have run the [branch formatter](https://github.com/nedap/formatting-stack/blob/332a419034ab46fad526a5592f4257353bd695b6/src/formatting_stack/branch_formatter.clj) and observed no new/significative warnings
* [x] The build passes
* [x] I have self-reviewed the PR prior to assignment
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [x] Correctness
  * [x] Robustness (red paths, failure handling etc)
  * [x] Modular design
  * [x] Test coverage
  * [x] Spec coverage
  * [x] Documentation
  * [x] Security
  * [x] Performance
  * [x] Breaking API changes
  * [x] Cross-compatibility (Clojure/ClojureScript)

## Reviewer checklist

* [ ] I have checked out this branch and reviewed it locally, running it
* [x] I have QAed the functionality
* [x] I have reviewed the PR
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [x] Correctness
  * [x] Robustness (red paths, failure handling etc)
  * [x] Modular design
  * [x] Test coverage
  * [x] Spec coverage
  * [x] Documentation
  * [x] Security
  * [x] Performance
  * [x] Breaking API changes
  * [ ] Cross-compatibility (Clojure/ClojureScript)
