### PR TITLE
v4.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ As you can see in the screenshot, **formatting-stack** presents linters' outputs
 #### Coordinates
 
 ```clojure
-[formatting-stack "4.0.1"]
+[formatting-stack "4.1.0"]
 ```
 
 **Also** you might have to add the [refactor-nrepl](https://github.com/clojure-emacs/refactor-nrepl) dependency.

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 ;; Please don't bump the library version by hand - use ci.release-workflow instead.
-(defproject formatting-stack "4.0.1"
+(defproject formatting-stack "4.1.0"
   ;; Please keep the dependencies sorted a-z.
   :dependencies [[clj-kondo "2020.01.13"]
                  [cljfmt "0.6.5" :exclusions [rewrite-clj]]


### PR DESCRIPTION
## Changelog

* https://github.com/nedap/formatting-stack/pull/142 - Upgrade our bundled Eastwood dependency. It is more performant
* https://github.com/nedap/formatting-stack/pull/143 - Don't use absolute file paths in our printed reports. This makes them more concise, therefore more repl-friendly.

## Release checklist (author)

* [x] All PRs / relevant commits since the previous release are listed in this PR's description 
* [x] The new proposed version follows semver 
* [x] The build passes
* [x] New features are (briefly) reflected in the README

## Release checklist (reviewer)

* [x] All PRs / relevant commits since the previous release are listed in this PR's description 
* [x] The new proposed version follows semver 
* [x] New features are (briefly) reflected in the README
