### PR TITLE
split pedantic from ncrw

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ commands:
             - v2-dependencies-{{ checksum "project.clj" }}
             # fallback to using the latest cache if no exact match is found
             - v2-dependencies-
-      - run: lein with-profile -dev,+stderr-report,+pedantic,+test,+refactor-nrepl deps
+      - run: lein with-profile -dev,+ci,+test,+refactor-nrepl deps
       - save_cache:
           paths:
             - ~/.m2
@@ -77,7 +77,7 @@ jobs:
           command: echo -e "$GPG_KEY_V2" | gpg --import
       - run:
           name: Perform pre-release sanity check
-          command: lein with-profile -dev,+ci run -m nedap.ci.release-workflow.api sanity-check
+          command: lein with-profile -dev,+ci,+ncrw run -m nedap.ci.release-workflow.api sanity-check
       - run:
           name: release to JFrog
           command: lein deploy
@@ -99,47 +99,47 @@ workflows:
       - test_code:
           name: "JDK 8 including refactor-nrepl"
           jdk_version: openjdk8
-          lein_test_command: lein with-profile -dev,+stderr-report,+pedantic,+refactor-nrepl do clean, test
+          lein_test_command: lein with-profile -dev,+ci,+refactor-nrepl do clean, test
           <<: *test_code_filters
       - test_code:
           name: "JDK 8 including refactor-nrepl, and parallel Eastwood linters"
           jdk_version: openjdk8-parallel
-          lein_test_command: lein with-profile -dev,+stderr-report,+pedantic,+refactor-nrepl,+parallel-eastwood do clean, test
+          lein_test_command: lein with-profile -dev,+ci,+refactor-nrepl,+parallel-eastwood do clean, test
           <<: *test_code_filters
       - test_code:
           name: "JDK 8 including refactor-nrepl (at its latest version)"
           jdk_version: openjdk8
-          lein_test_command: lein with-profile -dev,+stderr-report,+pedantic,+refactor-nrepl-latest do clean, test
+          lein_test_command: lein with-profile -dev,+ci,+refactor-nrepl-latest do clean, test
           <<: *test_code_filters
       - test_code:
           name: "JDK 8 excluding refactor-nrepl"
           jdk_version: openjdk8
-          lein_test_command: lein with-profile -dev,+stderr-report,+pedantic do clean, test
+          lein_test_command: lein with-profile -dev,+ci do clean, test
           <<: *test_code_filters
       - test_code:
           name: "JDK 8, with an old clojurescript dependency on the classpath"
           jdk_version: openjdk8
-          lein_test_command: lein with-profile -dev,-provided,+stderr-report,+pedantic,+cljs-old do clean, test
+          lein_test_command: lein with-profile -dev,-provided,+ci,+cljs-old do clean, test
           <<: *test_code_filters
       - test_code:
           name: "JDK 11 including refactor-nrepl"
           jdk_version: openjdk11
-          lein_test_command: lein with-profile -dev,+stderr-report,+pedantic,+refactor-nrepl do clean, test
+          lein_test_command: lein with-profile -dev,+ci,+refactor-nrepl do clean, test
           <<: *test_code_filters
       - test_code:
           name: "JDK 11 including refactor-nrepl, and parallel Eastwood linters"
           jdk_version: openjdk11-parallel
-          lein_test_command: lein with-profile -dev,+stderr-report,+pedantic,+refactor-nrepl,+parallel-eastwood do clean, test
+          lein_test_command: lein with-profile -dev,+ci,+refactor-nrepl,+parallel-eastwood do clean, test
           <<: *test_code_filters
       - test_code:
           name: "JDK 11 including refactor-nrepl (at its latest version)"
           jdk_version: openjdk11
-          lein_test_command: lein with-profile -dev,+stderr-report,+pedantic,+refactor-nrepl-latest do clean, test
+          lein_test_command: lein with-profile -dev,+ci,+refactor-nrepl-latest do clean, test
           <<: *test_code_filters
       - test_code:
           name: "JDK 11 excluding refactor-nrepl"
           jdk_version: openjdk11
-          lein_test_command: lein with-profile -dev,+stderr-report,+pedantic do clean, test
+          lein_test_command: lein with-profile -dev,+ci do clean, test
           <<: *test_code_filters
       - deploy:
           context: JFrog

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ commands:
             - v1-dependencies-{{ checksum "project.clj" }}
             # fallback to using the latest cache if no exact match is found
             - v1-dependencies-
-      - run: lein with-profile -dev,+test,+ci,+refactor-nrepl deps
+      - run: lein with-profile -dev,+pedantic,+test,+refactor-nrepl deps
       - save_cache:
           paths:
             - ~/.m2
@@ -99,47 +99,47 @@ workflows:
       - test_code:
           name: "JDK 8 including refactor-nrepl"
           jdk_version: openjdk8
-          lein_test_command: lein with-profile -dev,+ci,+refactor-nrepl do clean, test
+          lein_test_command: lein with-profile -dev,+pedantic,+refactor-nrepl do clean, test
           <<: *test_code_filters
       - test_code:
           name: "JDK 8 including refactor-nrepl, and parallel Eastwood linters"
           jdk_version: openjdk8-parallel
-          lein_test_command: lein with-profile -dev,+ci,+refactor-nrepl,+parallel-eastwood do clean, test
+          lein_test_command: lein with-profile -dev,+pedantic,+refactor-nrepl,+parallel-eastwood do clean, test
           <<: *test_code_filters
       - test_code:
           name: "JDK 8 including refactor-nrepl (at its latest version)"
           jdk_version: openjdk8
-          lein_test_command: lein with-profile -dev,+ci,+refactor-nrepl-latest do clean, test
+          lein_test_command: lein with-profile -dev,+pedantic,+refactor-nrepl-latest do clean, test
           <<: *test_code_filters
       - test_code:
           name: "JDK 8 excluding refactor-nrepl"
           jdk_version: openjdk8
-          lein_test_command: lein with-profile -dev,+ci do clean, test
+          lein_test_command: lein with-profile -dev,+pedantic do clean, test
           <<: *test_code_filters
       - test_code:
           name: "JDK 8, with an old clojurescript dependency on the classpath"
           jdk_version: openjdk8
-          lein_test_command: lein with-profile -dev,-provided,+ci,+cljs-old do clean, test
+          lein_test_command: lein with-profile -dev,-provided,+pedantic,+cljs-old do clean, test
           <<: *test_code_filters
       - test_code:
           name: "JDK 11 including refactor-nrepl"
           jdk_version: openjdk11
-          lein_test_command: lein with-profile -dev,+ci,+refactor-nrepl do clean, test
+          lein_test_command: lein with-profile -dev,+pedantic,+refactor-nrepl do clean, test
           <<: *test_code_filters
       - test_code:
           name: "JDK 11 including refactor-nrepl, and parallel Eastwood linters"
           jdk_version: openjdk11-parallel
-          lein_test_command: lein with-profile -dev,+ci,+refactor-nrepl,+parallel-eastwood do clean, test
+          lein_test_command: lein with-profile -dev,+pedantic,+refactor-nrepl,+parallel-eastwood do clean, test
           <<: *test_code_filters
       - test_code:
           name: "JDK 11 including refactor-nrepl (at its latest version)"
           jdk_version: openjdk11
-          lein_test_command: lein with-profile -dev,+ci,+refactor-nrepl-latest do clean, test
+          lein_test_command: lein with-profile -dev,+pedantic,+refactor-nrepl-latest do clean, test
           <<: *test_code_filters
       - test_code:
           name: "JDK 11 excluding refactor-nrepl"
           jdk_version: openjdk11
-          lein_test_command: lein with-profile -dev,+ci do clean, test
+          lein_test_command: lein with-profile -dev,+pedantic do clean, test
           <<: *test_code_filters
       - deploy:
           context: JFrog

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,14 +6,14 @@ commands:
       - checkout
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "project.clj" }}
+            - v2-dependencies-{{ checksum "project.clj" }}
             # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
+            - v2-dependencies-
       - run: lein with-profile -dev,+pedantic,+test,+refactor-nrepl deps
       - save_cache:
           paths:
             - ~/.m2
-          key: v1-dependencies-{{ checksum "project.clj" }}
+          key: v2-dependencies-{{ checksum "project.clj" }}
 
 executor_defaults: &executor_defaults
   working_directory: ~/repo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ commands:
             - v2-dependencies-{{ checksum "project.clj" }}
             # fallback to using the latest cache if no exact match is found
             - v2-dependencies-
-      - run: lein with-profile -dev,+pedantic,+test,+refactor-nrepl deps
+      - run: lein with-profile -dev,+stderr-report,+pedantic,+test,+refactor-nrepl deps
       - save_cache:
           paths:
             - ~/.m2
@@ -99,47 +99,47 @@ workflows:
       - test_code:
           name: "JDK 8 including refactor-nrepl"
           jdk_version: openjdk8
-          lein_test_command: lein with-profile -dev,+pedantic,+refactor-nrepl do clean, test
+          lein_test_command: lein with-profile -dev,+ci,+stderr-report,+pedantic,+refactor-nrepl do clean, test
           <<: *test_code_filters
       - test_code:
           name: "JDK 8 including refactor-nrepl, and parallel Eastwood linters"
           jdk_version: openjdk8-parallel
-          lein_test_command: lein with-profile -dev,+pedantic,+refactor-nrepl,+parallel-eastwood do clean, test
+          lein_test_command: lein with-profile -dev,+ci,+stderr-report,+pedantic,+refactor-nrepl,+parallel-eastwood do clean, test
           <<: *test_code_filters
       - test_code:
           name: "JDK 8 including refactor-nrepl (at its latest version)"
           jdk_version: openjdk8
-          lein_test_command: lein with-profile -dev,+pedantic,+refactor-nrepl-latest do clean, test
+          lein_test_command: lein with-profile -dev,+ci,+stderr-report,+pedantic,+refactor-nrepl-latest do clean, test
           <<: *test_code_filters
       - test_code:
           name: "JDK 8 excluding refactor-nrepl"
           jdk_version: openjdk8
-          lein_test_command: lein with-profile -dev,+pedantic do clean, test
+          lein_test_command: lein with-profile -dev,+ci,+stderr-report,+pedantic do clean, test
           <<: *test_code_filters
       - test_code:
           name: "JDK 8, with an old clojurescript dependency on the classpath"
           jdk_version: openjdk8
-          lein_test_command: lein with-profile -dev,-provided,+pedantic,+cljs-old do clean, test
+          lein_test_command: lein with-profile -dev,-provided,+ci,+stderr-report,+pedantic,+cljs-old do clean, test
           <<: *test_code_filters
       - test_code:
           name: "JDK 11 including refactor-nrepl"
           jdk_version: openjdk11
-          lein_test_command: lein with-profile -dev,+pedantic,+refactor-nrepl do clean, test
+          lein_test_command: lein with-profile -dev,+ci,+stderr-report,+pedantic,+refactor-nrepl do clean, test
           <<: *test_code_filters
       - test_code:
           name: "JDK 11 including refactor-nrepl, and parallel Eastwood linters"
           jdk_version: openjdk11-parallel
-          lein_test_command: lein with-profile -dev,+pedantic,+refactor-nrepl,+parallel-eastwood do clean, test
+          lein_test_command: lein with-profile -dev,+ci,+stderr-report,+pedantic,+refactor-nrepl,+parallel-eastwood do clean, test
           <<: *test_code_filters
       - test_code:
           name: "JDK 11 including refactor-nrepl (at its latest version)"
           jdk_version: openjdk11
-          lein_test_command: lein with-profile -dev,+pedantic,+refactor-nrepl-latest do clean, test
+          lein_test_command: lein with-profile -dev,+ci,+stderr-report,+pedantic,+refactor-nrepl-latest do clean, test
           <<: *test_code_filters
       - test_code:
           name: "JDK 11 excluding refactor-nrepl"
           jdk_version: openjdk11
-          lein_test_command: lein with-profile -dev,+pedantic do clean, test
+          lein_test_command: lein with-profile -dev,+ci,+stderr-report,+pedantic do clean, test
           <<: *test_code_filters
       - deploy:
           context: JFrog

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,47 +99,47 @@ workflows:
       - test_code:
           name: "JDK 8 including refactor-nrepl"
           jdk_version: openjdk8
-          lein_test_command: lein with-profile -dev,+ci,+stderr-report,+pedantic,+refactor-nrepl do clean, test
+          lein_test_command: lein with-profile -dev,+stderr-report,+pedantic,+refactor-nrepl do clean, test
           <<: *test_code_filters
       - test_code:
           name: "JDK 8 including refactor-nrepl, and parallel Eastwood linters"
           jdk_version: openjdk8-parallel
-          lein_test_command: lein with-profile -dev,+ci,+stderr-report,+pedantic,+refactor-nrepl,+parallel-eastwood do clean, test
+          lein_test_command: lein with-profile -dev,+stderr-report,+pedantic,+refactor-nrepl,+parallel-eastwood do clean, test
           <<: *test_code_filters
       - test_code:
           name: "JDK 8 including refactor-nrepl (at its latest version)"
           jdk_version: openjdk8
-          lein_test_command: lein with-profile -dev,+ci,+stderr-report,+pedantic,+refactor-nrepl-latest do clean, test
+          lein_test_command: lein with-profile -dev,+stderr-report,+pedantic,+refactor-nrepl-latest do clean, test
           <<: *test_code_filters
       - test_code:
           name: "JDK 8 excluding refactor-nrepl"
           jdk_version: openjdk8
-          lein_test_command: lein with-profile -dev,+ci,+stderr-report,+pedantic do clean, test
+          lein_test_command: lein with-profile -dev,+stderr-report,+pedantic do clean, test
           <<: *test_code_filters
       - test_code:
           name: "JDK 8, with an old clojurescript dependency on the classpath"
           jdk_version: openjdk8
-          lein_test_command: lein with-profile -dev,-provided,+ci,+stderr-report,+pedantic,+cljs-old do clean, test
+          lein_test_command: lein with-profile -dev,-provided,+stderr-report,+pedantic,+cljs-old do clean, test
           <<: *test_code_filters
       - test_code:
           name: "JDK 11 including refactor-nrepl"
           jdk_version: openjdk11
-          lein_test_command: lein with-profile -dev,+ci,+stderr-report,+pedantic,+refactor-nrepl do clean, test
+          lein_test_command: lein with-profile -dev,+stderr-report,+pedantic,+refactor-nrepl do clean, test
           <<: *test_code_filters
       - test_code:
           name: "JDK 11 including refactor-nrepl, and parallel Eastwood linters"
           jdk_version: openjdk11-parallel
-          lein_test_command: lein with-profile -dev,+ci,+stderr-report,+pedantic,+refactor-nrepl,+parallel-eastwood do clean, test
+          lein_test_command: lein with-profile -dev,+stderr-report,+pedantic,+refactor-nrepl,+parallel-eastwood do clean, test
           <<: *test_code_filters
       - test_code:
           name: "JDK 11 including refactor-nrepl (at its latest version)"
           jdk_version: openjdk11
-          lein_test_command: lein with-profile -dev,+ci,+stderr-report,+pedantic,+refactor-nrepl-latest do clean, test
+          lein_test_command: lein with-profile -dev,+stderr-report,+pedantic,+refactor-nrepl-latest do clean, test
           <<: *test_code_filters
       - test_code:
           name: "JDK 11 excluding refactor-nrepl"
           jdk_version: openjdk11
-          lein_test_command: lein with-profile -dev,+ci,+stderr-report,+pedantic do clean, test
+          lein_test_command: lein with-profile -dev,+stderr-report,+pedantic do clean, test
           <<: *test_code_filters
       - deploy:
           context: JFrog

--- a/project.clj
+++ b/project.clj
@@ -135,6 +135,5 @@
 
              :ncrw                  {:global-vars  {*assert* true} ;; `ci.release-workflow` relies on runtime assertions
                                      :dependencies [[com.nedap.staffing-solutions/ci.release-workflow "1.6.0"]]}
-             :pedantic              {:pedantic?    :abort}
-             :stderr-report         {:jvm-opts     ["-Dclojure.main.report=stderr"]}
-             :ci                    [:ncrw :pedantic :stderr-report]})
+             :ci                    {:pedantic?    :abort
+                                     :jvm-opts     ["-Dclojure.main.report=stderr"]}})

--- a/project.clj
+++ b/project.clj
@@ -135,6 +135,6 @@
 
              :ncrw                  {:global-vars  {*assert* true} ;; `ci.release-workflow` relies on runtime assertions
                                      :dependencies [[com.nedap.staffing-solutions/ci.release-workflow "1.6.0"]]}
-             :pedantic              {:pedantic?    :abort
-                                     :jvm-opts     ["-Dclojure.main.report=stderr"]}
-             :ci                    [:ncrw :pedantic]})
+             :pedantic              {:pedantic?    :abort}
+             :stderr-report         {:jvm-opts     ["-Dclojure.main.report=stderr"]}
+             :ci                    [:ncrw :pedantic :stderr-report]})

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
                  [com.gfredericks/how-to-ns "0.2.6"]
                  [com.gfredericks/lein-all-my-files-should-end-with-exactly-one-newline-character "0.1.1"]
                  [com.nedap.staffing-solutions/speced.def "2.0.0"]
-                 [com.nedap.staffing-solutions/utils.collections "2.0.0"]
+                 [com.nedap.staffing-solutions/utils.collections "2.1.0"]
                  [com.nedap.staffing-solutions/utils.modular "2.2.0-alpha3"]
                  [com.nedap.staffing-solutions/utils.spec.predicates "1.1.0"]
                  [jonase/eastwood "0.3.11"]
@@ -133,7 +133,8 @@
 
              :parallel-eastwood     {:jvm-opts ["-Dformatting-stack.eastwood.parallelize-linters=true"]}
 
-             :ci                    {:pedantic?    :abort
-                                     :jvm-opts     ["-Dclojure.main.report=stderr"]
-                                     :global-vars  {*assert* true} ;; `ci.release-workflow` relies on runtime assertions
-                                     :dependencies [[com.nedap.staffing-solutions/ci.release-workflow "1.6.0"]]}})
+             :ncrw                  {:global-vars  {*assert* true} ;; `ci.release-workflow` relies on runtime assertions
+                                     :dependencies [[com.nedap.staffing-solutions/ci.release-workflow "1.6.0"]]}
+             :pedantic              {:pedantic?    :abort
+                                     :jvm-opts     ["-Dclojure.main.report=stderr"]}
+             :ci                    [:ncrw :pedantic]})


### PR DESCRIPTION
## Brief

The CI failed if run without cache because it tried to fetch private dependencies.

By splitting `ci` profile in `ncrw` and `pedentic`, and bumping util.collections this is circumvented
<!-- Which issue does this PR fix? Ideally, create an issue if there was none, so the problem in question is well stated. -->

## QA plan

change cache key, run CI

<!-- Please state a reproducible plan to prove this PR works. Attach screenshots, gifs, etc. if needed. Occasionally, sufficient test coverage removes the need for QAing. -->

## Author checklist

<!-- Please, before publicizing your PR, open it as a "WIP PR", and then review it using the following. -->

* [x] I have QAed the functionality
* [x] The PR has a reasonably reviewable size and a meaningful commit history
* [x] I have run the [branch formatter](https://github.com/nedap/formatting-stack/blob/332a419034ab46fad526a5592f4257353bd695b6/src/formatting_stack/branch_formatter.clj) and observed no new/significative warnings
* [x] The build passes
* [x] I have self-reviewed the PR prior to assignment
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [x] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Modular design
  * [x] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
  * [ ] Cross-compatibility (Clojure/ClojureScript)

## Reviewer checklist

* [x] I have checked out this branch and reviewed it locally, running it
* [x] I have QAed the functionality
* [x] I have reviewed the PR
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [x] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Modular design
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
  * [ ] Cross-compatibility (Clojure/ClojureScript)
