### PR TITLE
Exception reporter bug

### DIFF
--- a/src/formatting_stack/reporters/impl.clj
+++ b/src/formatting_stack/reporters/impl.clj
@@ -1,12 +1,13 @@
 (ns formatting-stack.reporters.impl
   (:require
    [clojure.string :as string]
+   [medley.core :refer [assoc-some]]
    [nedap.speced.def :as speced]))
 
 (speced/defn normalize-filenames
   "Removes the CWD from the filenames, for more concise output, and also for ensuring correct grouping."
-  [{:keys [^string? filename] :as report}]
-  (assoc report :filename (-> filename
-                              (string/replace (re-pattern (str "^" (System/getProperty "user.dir")))
-                                              "")
-                              (string/replace #"^/" ""))))
+  [{:keys [^::speced/nilable ^string? filename] :as report}]
+  (assoc-some report :filename (some-> filename
+                                       (string/replace (re-pattern (str "^" (System/getProperty "user.dir")))
+                                                       "")
+                                       (string/replace #"^/" ""))))

--- a/src/formatting_stack/reporters/impl.clj
+++ b/src/formatting_stack/reporters/impl.clj
@@ -1,12 +1,18 @@
 (ns formatting-stack.reporters.impl
   (:require
+   [clojure.spec.alpha :as spec]
    [clojure.string :as string]
+   [formatting-stack.protocols.spec :as protocols.spec]
    [medley.core :refer [assoc-some]]
    [nedap.speced.def :as speced]))
 
+(speced/def-with-doc ::filename
+  "Filename which can be nil when an exception occurred"
+  (spec/nilable ::protocols.spec/filename))
+
 (speced/defn normalize-filenames
   "Removes the CWD from the filenames, for more concise output, and also for ensuring correct grouping."
-  [{:keys [^::speced/nilable ^string? filename] :as report}]
+  [{:keys [^::filename filename] :as report}]
   (assoc-some report :filename (some-> filename
                                        (string/replace (re-pattern (str "^" (System/getProperty "user.dir")))
                                                        "")

--- a/test/functional/formatting_stack/core.clj
+++ b/test/functional/formatting_stack/core.clj
@@ -1,0 +1,37 @@
+(ns functional.formatting-stack.core
+  (:require
+   [clojure.test :refer :all]
+   [formatting-stack.core :as sut]
+   [formatting-stack.protocols.formatter :as formatter]
+   [formatting-stack.protocols.reporter :as protocols.reporter]
+   [matcher-combinators.test :refer [match?]]
+   [nedap.utils.modular.api :refer [implement]])
+  (:import (clojure.lang ExceptionInfo)))
+
+(defn throw-exception [& args]
+  (throw (ex-info "Kaboom!" {})))
+
+(def failing-formatter
+  (implement {:id ::failing-formatter}
+    formatter/--format! throw-exception))
+
+(defn store-in-latest [{::keys [latest]} args]
+  (reset! latest args))
+
+(defn recording-recorder [latest]
+  (implement {::latest latest}
+    protocols.reporter/--report store-in-latest))
+
+(deftest format!
+  (testing "exceptions are passed to the reporter"
+    (let [x (atom nil)]
+      (sut/format! :formatters [failing-formatter]
+                   :linters []
+                   :processors []
+                   :reporter (recording-recorder x)
+                   :in-background? false)
+      (is (match? [{:source    :formatting-stack/process!
+                    :msg       "Exception during {:id :functional.formatting-stack.core/failing-formatter}"
+                    :level     :exception
+                    :exception #(instance? ExceptionInfo %)}]
+                  @x)))))

--- a/test/functional/formatting_stack/core.clj
+++ b/test/functional/formatting_stack/core.clj
@@ -6,7 +6,8 @@
    [formatting-stack.protocols.reporter :as protocols.reporter]
    [matcher-combinators.test :refer [match?]]
    [nedap.utils.modular.api :refer [implement]])
-  (:import (clojure.lang ExceptionInfo)))
+  (:import
+   (clojure.lang ExceptionInfo)))
 
 (defn throw-exception [& args]
   (throw (ex-info "Kaboom!" {})))
@@ -18,20 +19,20 @@
 (defn store-in-latest [{::keys [latest]} args]
   (reset! latest args))
 
-(defn recording-recorder [latest]
+(defn recording-reporter [latest]
   (implement {::latest latest}
     protocols.reporter/--report store-in-latest))
 
 (deftest format!
   (testing "exceptions are passed to the reporter"
-    (let [x (atom nil)]
+    (let [latest (atom nil)]
       (sut/format! :formatters [failing-formatter]
                    :linters []
                    :processors []
-                   :reporter (recording-recorder x)
+                   :reporter (recording-reporter latest)
                    :in-background? false)
       (is (match? [{:source    :formatting-stack/process!
                     :msg       "Exception during {:id :functional.formatting-stack.core/failing-formatter}"
                     :level     :exception
                     :exception #(instance? ExceptionInfo %)}]
-                  @x)))))
+                  @latest)))))

--- a/test/unit/formatting_stack/reporters/impl.clj
+++ b/test/unit/formatting_stack/reporters/impl.clj
@@ -9,7 +9,7 @@
                             (is (= {:filename expected}
                                    (sut/normalize-filenames {:filename input})))
                             true)
-      ""                      ""
+      nil                     nil
       "a"                     "a"
       cwd                     ""
       (str cwd "/a.clj")      "a.clj"


### PR DESCRIPTION
## Brief

discovered in #154, in some cases an exception occur, which are passed into reporter, without filenames. This is expected as the exception sometimes escapes the context where the filename is available (especially in `process-in-parallel!`).

This triggers a spec-error which hides the initial exception, as shown in the failing CI here: https://circleci.com/gh/nedap/formatting-stack/1818

<!-- Which issue does this PR fix? Ideally, create an issue if there was none, so the problem in question is well stated. -->

## QA plan

Fixed CI after `3a9c4a7` (revert to see breakage)

<!-- Please state a reproducible plan to prove this PR works. Attach screenshots, gifs, etc. if needed. Occasionally, sufficient test coverage removes the need for QAing. -->

## Author checklist

<!-- Please, before publicizing your PR, open it as a "WIP PR", and then review it using the following. -->

* [x] I have QAed the functionality
* [x] The PR has a reasonably reviewable size and a meaningful commit history
* [x] I have run the [branch formatter](https://github.com/nedap/formatting-stack/blob/332a419034ab46fad526a5592f4257353bd695b6/src/formatting_stack/branch_formatter.clj) and observed no new/significative warnings
* [ ] The build passes
* [ ] I have self-reviewed the PR prior to assignment
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [x] Correctness
  * [x] Robustness (red paths, failure handling etc)
  * [x] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
  * [ ] Cross-compatibility (Clojure/ClojureScript)

## Reviewer checklist

* [ ] I have checked out this branch and reviewed it locally, running it
* [ ] I have QAed the functionality
* [ ] I have reviewed the PR
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [ ] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
  * [ ] Cross-compatibility (Clojure/ClojureScript)
