### PR TITLE
do not calculate classpath-cache on require

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ As you can see in the screenshot, **formatting-stack** presents linters' outputs
 #### Coordinates
 
 ```clojure
-[formatting-stack "4.2.3"]
+[formatting-stack "4.2.4-alpha1"]
 ```
 
 **Also** you might have to add the [refactor-nrepl](https://github.com/clojure-emacs/refactor-nrepl) dependency.

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 ;; Please don't bump the library version by hand - use ci.release-workflow instead.
-(defproject formatting-stack "4.2.3"
+(defproject formatting-stack "4.2.4-alpha1"
   ;; Please keep the dependencies sorted a-z.
   :dependencies [[clj-kondo "2020.01.13"]
                  [cljfmt "0.6.5" :exclusions [rewrite-clj]]

--- a/worker/formatting_stack/kondo_classpath_cache.clj
+++ b/worker/formatting_stack/kondo_classpath_cache.clj
@@ -17,7 +17,7 @@
 (def cache-dir (str cache-parent-dir File/separator cache-subdir))
 
 (def classpath-cache
-  (future
+  (delay
     (let [files (-> (System/getProperty "java.class.path")
                     (string/split #"\:"))]
       (-> (File. cache-parent-dir cache-subdir) .mkdirs)


### PR DESCRIPTION
## Brief

This is reported to cause a lot of io, which could cause timeouts when when booting. By putting this into a delay the classpath-cache is calculated on the first kondo linter run.
<!-- Which issue does this PR fix? Ideally, create an issue if there was none, so the problem in question is well stated. -->

## QA plan

 1. release alpha
 1. remove `.clj-kondo`-folder from projects known to cause this issue
 1. boot repl; observe no timeout
 1. run f-s; observe creation of cache
 1. run f-s again; observe faster run

## Author checklist

<!-- Please, before publicizing your PR, open it as a "WIP PR", and then review it using the following. -->

* [ ] I have QAed the functionality
* [ ] The PR has a reasonably reviewable size and a meaningful commit history
* [ ] I have run the [branch formatter](https://github.com/nedap/formatting-stack/blob/332a419034ab46fad526a5592f4257353bd695b6/src/formatting_stack/branch_formatter.clj) and observed no new/significative warnings
* [ ] The build passes
* [ ] I have self-reviewed the PR prior to assignment
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [ ] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
  * [ ] Cross-compatibility (Clojure/ClojureScript)

## Reviewer checklist

* [ ] I have checked out this branch and reviewed it locally, running it
* [ ] I have QAed the functionality
* [ ] I have reviewed the PR
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [ ] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
  * [ ] Cross-compatibility (Clojure/ClojureScript)
