### PR TITLE
Parallelize `namespaces-within-refresh-dirs-only`

### DIFF
--- a/test/integration/formatting_stack/strategies.clj
+++ b/test/integration/formatting_stack/strategies.clj
@@ -1,9 +1,12 @@
 (ns integration.formatting-stack.strategies
   (:require
    [clojure.java.shell :refer [sh]]
+   [clojure.set :as set]
    [clojure.string :as string]
    [clojure.test :refer [deftest is testing]]
-   [formatting-stack.strategies :as sut])
+   [formatting-stack.strategies :as sut]
+   [formatting-stack.util :refer [rcomp]]
+   [nedap.speced.def :as speced])
   (:import
    (java.io File)))
 
@@ -235,3 +238,18 @@
         (sh "rm" (str rename-destination))
         (assert (-> deletable-file .exists))
         (assert (not (-> rename-destination .exists)))))))
+
+(deftest namespaces-within-refresh-dirs-only
+  (speced/let [^{::speced/spec (rcomp count (partial < 100))}
+               all-files (sut/all-files :files [])
+               result (sut/namespaces-within-refresh-dirs-only :files all-files)]
+    (is (seq result)
+        "Returns non-empty results (since f-s itself has namespaces within `src`, `test`, etc)")
+
+    (is (< (count result)
+           (count all-files))
+        "Doesn't include files outside the refresh dirs")
+
+    (is (set/subset? (set result)
+                     (set all-files))
+        "Is a substractive (and not additive) mechanism")))


### PR DESCRIPTION
## Brief

Fixes nedap/formatting-stack#168

## QA plan

It can be observed that the included test passes even when undoing the fix.

I also verified the performance improvement described in https://github.com/nedap/formatting-stack/issues/168, in a repl that loads a large codebase:

#### Before

![image](https://user-images.githubusercontent.com/1162994/111339436-0bf90a00-8678-11eb-8910-df7efec39158.png)

#### After

![image](https://user-images.githubusercontent.com/1162994/111339738-495d9780-8678-11eb-8e27-ef961c3ec037.png)

## Author checklist

<!-- Please, before publicizing your PR, open it as a "WIP PR", and then review it using the following. -->

* [x] I have QAed the functionality
* [x] The PR has a reasonably reviewable size and a meaningful commit history
* [x] I have run the [branch formatter](https://github.com/nedap/formatting-stack/blob/332a419034ab46fad526a5592f4257353bd695b6/src/formatting_stack/branch_formatter.clj) and observed no new/significative warnings
* [ ] The build passes
* [x] I have self-reviewed the PR prior to assignment
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [x] Correctness
  * [x] Robustness (red paths, failure handling etc)
  * [x] Test coverage
  * [x] Spec coverage
  * [x] Documentation
  * [x] Security
  * [x] Performance
  * [x] Breaking API changes
  * [x] Cross-compatibility (Clojure/ClojureScript)

## Reviewer checklist

* [ ] I have checked out this branch and reviewed it locally, running it
* [ ] I have QAed the functionality
* [x] I have reviewed the PR
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [x] Correctness
  * [x] Robustness (red paths, failure handling etc)
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [x] Performance
  * [x] Breaking API changes
  * [x] Cross-compatibility (Clojure/ClojureScript)
