### PR TITLE
Forbid read-eval syntax in formatted/linted files

### DIFF
--- a/src/formatting_stack/formatters/clean_ns/impl.clj
+++ b/src/formatting_stack/formatters/clean_ns/impl.clj
@@ -10,7 +10,8 @@
    (clojure.lang Namespace)))
 
 (speced/defn safely-read-ns-contents [^string? buffer, ^Namespace ns-obj]
-  (binding [tools.reader/*alias-map* (ns-aliases ns-obj)]
+  (binding [tools.reader/*read-eval* false
+            tools.reader/*alias-map* (ns-aliases ns-obj)]
     (tools.reader/read-string {:read-cond :allow
                                :features  #{:clj}}
                               (str "[ " buffer " ]"))))

--- a/src/formatting_stack/linters/eastwood.clj
+++ b/src/formatting_stack/linters/eastwood.clj
@@ -2,9 +2,12 @@
   (:require
    [clojure.java.io :as io]
    [clojure.string :as str]
+   [clojure.tools.reader :as tools.reader]
    [eastwood.lint]
+   [formatting-stack.formatters.clean-ns.impl :refer [safely-read-ns-contents]]
    [formatting-stack.linters.eastwood.impl :as impl]
    [formatting-stack.protocols.linter :as linter]
+   [formatting-stack.strategies.impl :refer [filename->ns]]
    [formatting-stack.util :refer [ns-name-from-filename]]
    [medley.core :refer [assoc-some deep-merge]]
    [nedap.utils.modular.api :refer [implement]])
@@ -16,7 +19,7 @@
   (let [linters (remove #{:suspicious-test :unused-ret-vals :constant-test :wrong-tag}
                         eastwood.lint/default-linters)]
     (-> eastwood.lint/default-opts
-        (assoc :linters linters
+        (assoc :linters             linters
                :rethrow-exceptions? true))))
 
 (def parallelize-linters? (System/getProperty "formatting-stack.eastwood.parallelize-linters"))
@@ -27,34 +30,43 @@
         "The formatting-stack config file must exist and be prefixed by `eastwood/config`
 (note that this prefix must not be passed to Eastwood itself).")
 
+(defn assert-no-read-eval-contained! [filename]
+  (binding [tools.reader/*read-eval* false]
+    (when-let [n (filename->ns filename)]
+      (safely-read-ns-contents (slurp filename)
+                               n)))
+  filename)
+
 (defn lint! [{:keys [options]} filenames]
-  (let [namespaces (->> filenames
-                        (remove #(str/ends-with? % ".edn"))
-                        (keep ns-name-from-filename))
-        reports    (atom nil)
-        exceptions (atom nil)
-        output     (with-out-str
-                     (binding [*warn-on-reflection* true]
-                       (try
-                         (cond-> options
-                           true                 (assoc :namespaces namespaces)
-                           parallelize-linters? (update :builtin-config-files conj config-filename)
-                           true                 (eastwood.lint/eastwood (impl/->TrackingReporter reports)))
-                         (catch Exception e
-                           (swap! exceptions conj e)))))]
-    (->> @reports
-         :warnings
-         (map :warn-data)
-         (map (fn [{:keys [uri-or-file-name linter] :strs [warning-details-url] :as m}]
-                (assoc-some m
-                            :level               :warning
-                            :source              (keyword "eastwood" (name linter))
-                            :warning-details-url warning-details-url
-                            :filename            (if (string? uri-or-file-name)
-                                                   uri-or-file-name
-                                                   (-> ^File uri-or-file-name .getCanonicalPath)))))
-         (concat (impl/warnings->reports output)
-                 (impl/exceptions->reports @exceptions)))))
+  (binding [*read-eval* false]
+    (let [namespaces (->> filenames
+                          (map assert-no-read-eval-contained!)
+                          (remove #(str/ends-with? % ".edn"))
+                          (keep ns-name-from-filename))
+          reports    (atom nil)
+          exceptions (atom nil)
+          output     (with-out-str
+                       (binding [*warn-on-reflection* true]
+                         (try
+                           (cond-> options
+                             true                 (assoc :namespaces namespaces)
+                             parallelize-linters? (update :builtin-config-files conj config-filename)
+                             true                 (eastwood.lint/eastwood (impl/->TrackingReporter reports)))
+                           (catch Exception e
+                             (swap! exceptions conj e)))))]
+      (->> @reports
+           :warnings
+           (map :warn-data)
+           (map (fn [{:keys [uri-or-file-name linter] :strs [warning-details-url] :as m}]
+                  (assoc-some m
+                              :level               :warning
+                              :source              (keyword "eastwood" (name linter))
+                              :warning-details-url warning-details-url
+                              :filename            (if (string? uri-or-file-name)
+                                                     uri-or-file-name
+                                                     (-> ^File uri-or-file-name .getCanonicalPath)))))
+           (concat (impl/warnings->reports output)
+                   (impl/exceptions->reports @exceptions))))))
 
 (defn new [{:keys [eastwood-options]
             :or   {eastwood-options {}}}]

--- a/src/formatting_stack/util/ns.clj
+++ b/src/formatting_stack/util/ns.clj
@@ -27,10 +27,11 @@
          (apply =))))
 
 (speced/defn safely-read-ns-form [^::ns-form-str ns-form-str]
-  (-> (tools.reader/read-string {:read-cond :preserve
-                                 :features  #{:clj :cljs}}
-                                (str "[ " ns-form-str " ]"))
-      first))
+  (binding [tools.reader/*read-eval* false]
+    (-> (tools.reader/read-string {:read-cond :preserve
+                                   :features  #{:clj :cljs}}
+                                  (str "[ " ns-form-str " ]"))
+        first)))
 
 (speced/defn replaceable-ns-form
   [^string? filename, ^ifn? ns-cleaner, ^map? how-to-ns-opts]

--- a/test/functional/formatting_stack/linters/eastwood/examples/read_eval.clj
+++ b/test/functional/formatting_stack/linters/eastwood/examples/read_eval.clj
@@ -1,0 +1,3 @@
+(ns functional.formatting-stack.linters.eastwood.examples.read-eval)
+
+#=(clojure.core/identity 42)

--- a/test/functional/formatting_stack/linters/eastwood/examples/read_eval_2.clj
+++ b/test/functional/formatting_stack/linters/eastwood/examples/read_eval_2.clj
@@ -1,0 +1,3 @@
+(ns functional.formatting-stack.linters.eastwood.examples.read-eval-2)
+
+(read-string "#=(clojure.core/identity 42)")


### PR DESCRIPTION
## Brief

#### Forbid read-eval syntax in formatted/linted files

This particularly targets Eastwood (since it's the only member of our stack that evals code, and therefore can run read-eval syntax) and tools.reader (which we internally use for various purposes).

It also is bound at `formatting-stack.core` level in case any other mechanisms happen to be sensitive.

Fixes nedap/formatting-stack#158

## QA plan

* Lint formatting-stack itself via the `project` or `branch` formatter
  * Note that Eastwood will complain due to the two test namespaces that intentionally fail (functional.formatting-stack.linters.eastwood.examples.read-eval, functional.formatting-stack.linters.eastwood.examples.read-eval-2)
  *  Note that they must be placed in `test` and not `test-resources`, since ns parsing (and refresh-dirs parsing) is part of how our Eastwood integration works
    * This can be slightly inconvenient in a future when we dogood f-s in CI (not done atm), by then we could simply exclude these two files with a `strategy`.

## Author checklist

<!-- Please, before publicizing your PR, open it as a "WIP PR", and then review it using the following. -->

* [x] I have QAed the functionality
* [x] The PR has a reasonably reviewable size and a meaningful commit history
* [x] I have run the [branch formatter](https://github.com/nedap/formatting-stack/blob/332a419034ab46fad526a5592f4257353bd695b6/src/formatting_stack/branch_formatter.clj) and observed no new/significative warnings
* [ ] The build passes
* [x] I have self-reviewed the PR prior to assignment
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [x] Correctness
  * [x] Robustness (red paths, failure handling etc)
  * [x] Test coverage
  * [x] Spec coverage
  * [ ] Documentation
    * Worth adding an explanation to the https://github.com/nedap/formatting-stack/wiki/FAQ
  * [x] Security
  * [x] Performance
  * [x] Breaking API changes
    * Strictly speaking this would break a consumer that used `#=()` syntax. However `#=` is not part of the Clojure API: it's absent from https://clojure.org/reference/reader#_dispatch , https://clojure.org/guides/weird_characters
    * I do think it's good that f-s communicates that using `#=()` is a problem. My experience was that `#=()` can be detected and fixed.
  * [x] Cross-compatibility (Clojure/ClojureScript)

## Reviewer checklist

* [ ] I have checked out this branch and reviewed it locally, running it
* [ ] I have QAed the functionality
* [ ] I have reviewed the PR
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [ ] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
  * [ ] Cross-compatibility (Clojure/ClojureScript)
