### PR TITLE
Add opt-in lazy computation of the clj-kondo classpath cache

### DIFF
--- a/test/functional/formatting_stack/kondo_classpath_cache.clj
+++ b/test/functional/formatting_stack/kondo_classpath_cache.clj
@@ -12,7 +12,7 @@
       (is (apply = arglists))))
 
   (let [proof (atom nil)]
-    (are [input expected] (do
+    (are [input expected] (testing "All arguments passed to the `body` are evaluated"
                             (reset! proof [])
                             (is (= expected
                                    input))

--- a/test/functional/formatting_stack/kondo_classpath_cache.clj
+++ b/test/functional/formatting_stack/kondo_classpath_cache.clj
@@ -1,0 +1,21 @@
+(ns functional.formatting-stack.kondo-classpath-cache
+  (:require
+   [clojure.test :refer [are deftest is testing]]
+   [formatting-stack.kondo-classpath-cache :as sut]
+   [formatting-stack.util :refer [rcomp]]))
+
+(deftest runner
+  (testing "All choices have identical arglists (and therefore can be swapped transparently)"
+    (let [arglists (->> sut/runner-mapping vals (map (rcomp find-var meta :arglists)))]
+      (assert (seq arglists))
+      (assert (every? some? arglists))
+      (is (apply = arglists))))
+
+  (let [proof (atom nil)]
+    (are [input expected] (do
+                            (reset! proof [])
+                            (is (= expected
+                                   input))
+                            true)
+      @(sut/runner (swap! proof conj 1))                      [1]
+      @(sut/runner (swap! proof conj 1) (swap! proof conj 2)) [1 2])))

--- a/worker/formatting_stack/kondo_classpath_cache.clj
+++ b/worker/formatting_stack/kondo_classpath_cache.clj
@@ -8,6 +8,21 @@
   (:import
    (java.io File)))
 
+(def runner-mapping
+  {"future" `future
+   "delay"  `delay})
+
+(def ^:private runner-choice
+  (-> runner-mapping
+      (get (System/getProperty "formatting-stack.kondo-classpath-cache.runner", "future"))
+      (doto assert)))
+
+(defmacro runner
+  {:style/indent 0}
+  [& body]
+  {:pre [(seq body)]}
+  (apply list runner-choice body))
+
 ;; Use kondo's official default config dir, so that we don't bloat consumers' project layouts:
 (def cache-parent-dir ".clj-kondo")
 
@@ -17,7 +32,7 @@
 (def cache-dir (str cache-parent-dir File/separator cache-subdir))
 
 (def classpath-cache
-  (future
+  (runner
     (let [files (-> (System/getProperty "java.class.path")
                     (string/split #"\:"))]
       (-> (File. cache-parent-dir cache-subdir) .mkdirs)


### PR DESCRIPTION
## Brief

Fixes nedap/formatting-stack#175

## QA plan

* Open a repl having set `"-Dformatting-stack.kondo-classpath-cache.runner=delay"` beforehand
* Observe that `@#'formatting-stack.kondo-classpath-cache/runner-choice` evals to `clojure.core/delay`
* Observe that `formatting-stack.kondo-classpath-cache/classpath-cache` is a non-derefed `Delay` object
* deref said object
* note that it takes a while (proving the deferred computation) and then it returns its usual value.

## Author checklist

<!-- Please, before publicizing your PR, open it as a "WIP PR", and then review it using the following. -->

* [x] I have QAed the functionality
* [x] The PR has a reasonably reviewable size and a meaningful commit history
* [x] I have run the [branch formatter](https://github.com/nedap/formatting-stack/blob/332a419034ab46fad526a5592f4257353bd695b6/src/formatting_stack/branch_formatter.clj) and observed no new/significative warnings
* [ ] The build passes
* [x] I have self-reviewed the PR prior to assignment
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [x] Correctness
  * [x] Robustness (red paths, failure handling etc)
  * [x] Test coverage
  * [x] Spec coverage
  * [x] Documentation
    * intentionally not documented.
  * [x] Security
  * [x] Performance
  * [x] Breaking API changes
  * [x] Cross-compatibility (Clojure/ClojureScript)

## Reviewer checklist

* [ ] I have checked out this branch and reviewed it locally, running it
* [ ] I have QAed the functionality
* [ ] I have reviewed the PR
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [ ] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
  * [ ] Cross-compatibility (Clojure/ClojureScript)
