### PR TITLE
Cover monorepo support with an e2e test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,6 +68,8 @@ jobs:
       - setup-env
       - run:
           command: << parameters.lein_test_command >>
+      - run:
+          command: .circleci/e2e.sh
   deploy:
     executor: openjdk8
     steps:

--- a/.circleci/e2e.sh
+++ b/.circleci/e2e.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+project_dir=$PWD
+set -Eeuxo pipefail
+cd e2e/monorepo-support
+
+
+if [[ ! -e $project_dir/.git ]]; then
+  echo "Expected formatting-stack to be a Git repo"
+  exit 1
+fi
+
+if [[ -e .git ]]; then
+  echo "monorepo-support is meant to emulate monorepos. It should not have its own Git repository; that would alter formatting-stack output"
+  exit 1
+fi
+
+mkdir checkouts
+cd checkouts
+ln -s $project_dir formatting-stack
+cd ..
+echo "(ns foo)" > src/foo.clj
+echo "(ns bar)" > src/bar.clj
+git add src/foo.clj
+lein with-profile -dev do clean, test
+git reset src/foo.clj
+rm src/foo.clj
+rm src/bar.clj

--- a/e2e/monorepo-support/project.clj
+++ b/e2e/monorepo-support/project.clj
@@ -1,0 +1,4 @@
+(defproject monorepo-support "unreleased"
+  :dependencies [[org.clojure/clojure "1.10.1"]
+                 ;; the version doesn't matter a lot - it will be overriden via Lein checkouts:
+                 [formatting-stack "4.3.0"]])

--- a/e2e/monorepo-support/test/monorepo_support/core_test.clj
+++ b/e2e/monorepo-support/test/monorepo_support/core_test.clj
@@ -1,0 +1,31 @@
+(ns monorepo-support.core-test
+  (:require
+   [clojure.set :as set]
+   [clojure.test :refer [are deftest is testing use-fixtures]]
+   [formatting-stack.strategies])
+  (:import
+   (java.io File)))
+
+(deftest e2e
+  (let [all (set (formatting-stack.strategies/all-files :files []))
+        staged (set (formatting-stack.strategies/git-completely-staged :files []))
+        unstaged (set (formatting-stack.strategies/git-not-completely-staged :files []))
+        staged+unstaged (into staged unstaged)]
+    (is (seq all))
+    (is (seq staged))
+    (is (seq unstaged))
+
+    (is (not= staged unstaged))
+    (is (> (count all)
+           (count staged+unstaged)))
+    (is (set/superset? all staged+unstaged))
+
+    (doseq [filename all
+            :let [file (File. filename)
+                  absolute (-> file .getAbsolutePath)]]
+      (is (= filename
+             absolute)
+          "Returns absolutized filenames, which is important for monorepo support")
+
+      (is (-> file .exists)
+          "Said absolutized filenames reflect files that actually exist"))))


### PR DESCRIPTION
## Brief

Fixes nedap/formatting-stack#139

Emulates a true monorepo via a subproject. i.e., uses formatting-stack's .git, but when running the subproject's test suite, its pwd will be more nested than the main suite's pwd.

## QA plan

* Remove `(cons "--full-name")` (as seen in the PR diff), commit that
* Note how the normal `lein test` passes, but `e2e.sh` doesn't.

Per my personal CircleCI account:

![image](https://user-images.githubusercontent.com/1162994/111854352-1a1c8400-891f-11eb-8d75-dd644a994ddb.png)


## Author checklist

<!-- Please, before publicizing your PR, open it as a "WIP PR", and then review it using the following. -->

* [x] I have QAed the functionality
* [x] The PR has a reasonably reviewable size and a meaningful commit history
* [x] I have run the [branch formatter](https://github.com/nedap/formatting-stack/blob/332a419034ab46fad526a5592f4257353bd695b6/src/formatting_stack/branch_formatter.clj) and observed no new/significative warnings
* [x] The build passes
* [x] I have self-reviewed the PR prior to assignment
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [x] Correctness
  * [x] Robustness (red paths, failure handling etc)
  * [x] Test coverage
  * [x] Spec coverage
  * [x] Documentation
  * [x] Security
  * [x] Performance
  * [x] Breaking API changes
  * [x] Cross-compatibility (Clojure/ClojureScript)

## Reviewer checklist

* [ ] I have checked out this branch and reviewed it locally, running it
* [ ] I have QAed the functionality
* [ ] I have reviewed the PR
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [ ] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
  * [ ] Cross-compatibility (Clojure/ClojureScript)
