### PR TITLE
CI: adopt matrix syntax

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,64 +93,33 @@ test_code_filters: &test_code_filters
       only: /^v\d+\.\d+\.\d+(-alpha\d+)?$/
 
 workflows:
-  version: 2.1
   ci-test-matrix:
     jobs:
       - test_code:
-          name: "JDK 8 including refactor-nrepl"
-          jdk_version: openjdk8
-          lein_test_command: lein with-profile -dev,+ci,+refactor-nrepl do clean, test
-          <<: *test_code_filters
+          matrix:
+            <<: *test_code_filters
+            alias: "test_code_base"
+            parameters:
+              jdk_version: ["openjdk8","openjdk11"]
+              lein_test_command:
+                - "lein with-profile -dev,+ci do clean, test"
+                - "lein with-profile -dev,-provided,+ci,+cljs-old do clean, test"
+                - "lein with-profile -dev,+ci,+refactor-nrepl do clean, test"
+                - "lein with-profile -dev,+ci,+refactor-nrepl-latest do clean, test"
       - test_code:
-          name: "JDK 8 including refactor-nrepl, and parallel Eastwood linters"
-          jdk_version: openjdk8-parallel
-          lein_test_command: lein with-profile -dev,+ci,+refactor-nrepl,+parallel-eastwood do clean, test
-          <<: *test_code_filters
-      - test_code:
-          name: "JDK 8 including refactor-nrepl (at its latest version)"
-          jdk_version: openjdk8
-          lein_test_command: lein with-profile -dev,+ci,+refactor-nrepl-latest do clean, test
-          <<: *test_code_filters
-      - test_code:
-          name: "JDK 8 excluding refactor-nrepl"
-          jdk_version: openjdk8
-          lein_test_command: lein with-profile -dev,+ci do clean, test
-          <<: *test_code_filters
-      - test_code:
-          name: "JDK 8, with an old clojurescript dependency on the classpath"
-          jdk_version: openjdk8
-          lein_test_command: lein with-profile -dev,-provided,+ci,+cljs-old do clean, test
-          <<: *test_code_filters
-      - test_code:
-          name: "JDK 11 including refactor-nrepl"
-          jdk_version: openjdk11
-          lein_test_command: lein with-profile -dev,+ci,+refactor-nrepl do clean, test
-          <<: *test_code_filters
-      - test_code:
-          name: "JDK 11 including refactor-nrepl, and parallel Eastwood linters"
-          jdk_version: openjdk11-parallel
-          lein_test_command: lein with-profile -dev,+ci,+refactor-nrepl,+parallel-eastwood do clean, test
-          <<: *test_code_filters
-      - test_code:
-          name: "JDK 11 including refactor-nrepl (at its latest version)"
-          jdk_version: openjdk11
-          lein_test_command: lein with-profile -dev,+ci,+refactor-nrepl-latest do clean, test
-          <<: *test_code_filters
-      - test_code:
-          name: "JDK 11 excluding refactor-nrepl"
-          jdk_version: openjdk11
-          lein_test_command: lein with-profile -dev,+ci do clean, test
-          <<: *test_code_filters
+          matrix:
+            <<: *test_code_filters
+            alias: "test_code_parallel_eastwood"
+            parameters:
+              jdk_version: ["openjdk8-parallel", "openjdk11-parallel"]
+              lein_test_command:
+                - "lein with-profile -dev,+ci,+refactor-nrepl,+parallel-eastwood do clean, test"
+                - "lein with-profile -dev,+ci,+refactor-nrepl-latest,+parallel-eastwood do clean, test"
       - deploy:
           context: JFrog
           requires:
-            - "JDK 8, with an old clojurescript dependency on the classpath"
-            - "JDK 8 including refactor-nrepl, and parallel Eastwood linters"
-            - "JDK 8 including refactor-nrepl"
-            - "JDK 8 excluding refactor-nrepl"
-            - "JDK 11 including refactor-nrepl"
-            - "JDK 11 including refactor-nrepl, and parallel Eastwood linters"
-            - "JDK 11 excluding refactor-nrepl"
+            - "test_code_base"
+            - "test_code_parallel_eastwood"
           filters:
             branches:
               ignore: /.*/


### PR DESCRIPTION
## Brief

The project's build matrix predates CircleCI's matrix syntax. By using it, the build file can grow more sustainably - in particular we can add more elements / dimensions without having to review/adapt everything.

## QA plan

Build this branch and observe that each named job is different and actually results in different setups/commands being executed.

![image](https://user-images.githubusercontent.com/1162994/112697336-9d8e2600-8e87-11eb-95bd-d137c18c2103.png)

## Author checklist

<!-- Please, before publicizing your PR, open it as a "WIP PR", and then review it using the following. -->

* [x] I have QAed the functionality
* [x] The PR has a reasonably reviewable size and a meaningful commit history
* [ ] I have run the [branch formatter](https://github.com/nedap/formatting-stack/blob/332a419034ab46fad526a5592f4257353bd695b6/src/formatting_stack/branch_formatter.clj) and observed no new/significative warnings
* [x] The build passes
* [x] I have self-reviewed the PR prior to assignment
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [x] Correctness
  * [x] Robustness (red paths, failure handling etc)
  * [ ] Test coverage
  * [ ] Spec coverage
  * [x] Documentation
  * [x] Security
  * [x] Performance
  * [x] Breaking API changes
  * [x] Cross-compatibility (Clojure/ClojureScript)

## Reviewer checklist

* [ ] I have checked out this branch and reviewed it locally, running it
* [ ] I have QAed the functionality
* [ ] I have reviewed the PR
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [ ] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
  * [ ] Cross-compatibility (Clojure/ClojureScript)
