### PR TITLE
Eastwood: always use absolute filenames, internally

### DIFF
--- a/src/formatting_stack/linters/eastwood/impl.clj
+++ b/src/formatting_stack/linters/eastwood/impl.clj
@@ -3,7 +3,9 @@
    [clojure.string :as string]
    [eastwood.reporting-callbacks :as reporting-callbacks]
    [formatting-stack.protocols.spec :as protocols.spec]
-   [nedap.speced.def :as speced]))
+   [nedap.speced.def :as speced])
+  (:import
+   (java.io File)))
 
 (speced/defn ^boolean? contains-dynamic-assertions?
   "Does this linting result refer to a :pre/:post containing dynamic assertions?
@@ -36,8 +38,8 @@ See https://git.io/fhQTx"
   [^string? warnings]
   (->> warnings
        (re-seq #"(.*):(\d+):(\d+): Reflection warning - (.+)\.")
-       (map (fn [[_, filename, line, column, msg]]
-              {:filename filename
+       (map (speced/fn [[_, ^String filename, line, column, msg]]
+              {:filename (-> filename File. .getCanonicalPath)
                :line     (Long/parseLong line)
                :column   (Long/parseLong column)
                :msg      msg


### PR DESCRIPTION
## Brief

Part of https://github.com/nedap/formatting-stack/issues/169

As a prerequisite for #169, I found out that filenames coming from Eastwood reports should be _absolute_, otherwise they wouldn't match with filenames computed by a 'linter caching' mechanism. Of course, a key mismatch means no cache hits.

This is the data path as of `master`:

* f-s sends an absolutized filename (via our git strategies) to Eastwood
* Eastwood may return wither a File (which will be stringed, absolutized) or a string (which will be a relative filename)

This PR proposes making the data path always `absolutized filename` -> `absolutized filename`.

## QA plan

Verify that Eastwood keeps emitting reports when a fault arises, in vanilla repos and monorepos alike.

⚠️The report should be rendered with relativized filenames (as it's a friendly/concise UI), as always.

## Author checklist

<!-- Please, before publicizing your PR, open it as a "WIP PR", and then review it using the following. -->

* [ ] I have QAed the functionality
* [ ] The PR has a reasonably reviewable size and a meaningful commit history
* [ ] I have run the [branch formatter](https://github.com/nedap/formatting-stack/blob/332a419034ab46fad526a5592f4257353bd695b6/src/formatting_stack/branch_formatter.clj) and observed no new/significative warnings
* [ ] The build passes
* [ ] I have self-reviewed the PR prior to assignment
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [ ] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
  * [ ] Cross-compatibility (Clojure/ClojureScript)

## Reviewer checklist

* [ ] I have checked out this branch and reviewed it locally, running it
* [ ] I have QAed the functionality
* [ ] I have reviewed the PR
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [ ] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
  * [ ] Cross-compatibility (Clojure/ClojureScript)
