### PR TITLE
Fix `*print-length*` behaviour in formatters

### DIFF
--- a/src/formatting_stack/formatters/clean_ns.clj
+++ b/src/formatting_stack/formatters/clean_ns.clj
@@ -4,7 +4,7 @@
    [formatting-stack.formatters.how-to-ns]
    [formatting-stack.protocols.formatter :as formatter]
    [formatting-stack.protocols.linter :as linter]
-   [formatting-stack.util :refer [ensure-sequential process-in-parallel! try-require]]
+   [formatting-stack.util :refer [ensure-sequential process-in-parallel! try-require unlimited-pr-str]]
    [formatting-stack.util.diff :as diff :refer [diff->line-numbers]]
    [formatting-stack.util.ns :as util.ns :refer [write-ns-replacement!]]
    [medley.core :refer [deep-merge]]
@@ -19,7 +19,7 @@
                                  :original-ns-form                     original-ns-form
                                  :namespaces-that-should-never-cleaned namespaces-that-should-never-cleaned
                                  :libspec-whitelist                    libspec-whitelist})
-            pr-str)))
+            unlimited-pr-str)))
 
 (def default-libspecs
   ["specs" "imports" "exports" "extensions" "side-effects" "init" "initialization" "load" "migration" "migrations"])

--- a/src/formatting_stack/formatters/cljfmt/impl.clj
+++ b/src/formatting_stack/formatters/cljfmt/impl.clj
@@ -7,7 +7,7 @@
    [clojure.tools.namespace.parse :as parse]
    [formatting-stack.indent-specs]
    [formatting-stack.project-parsing :refer [project-namespaces]]
-   [formatting-stack.util :refer [dissoc-by rcomp require-lock]]
+   [formatting-stack.util :refer [dissoc-by rcomp require-lock unlimited-pr-str]]
    [nedap.speced.def :as speced]))
 
 (def ^:dynamic *cache* nil)
@@ -99,8 +99,8 @@
     (swap! result
            #(-> %
                 (dissoc-by (fn [x] ;; regexes can't be compared, hence this contraption
-                             (not= (pr-str x)
-                                   (pr-str #"^def"))))
+                             (not= (unlimited-pr-str x)
+                                   (unlimited-pr-str #"^def"))))
                 (assoc #"^def(?!ault)(?!late)(?!er)" [[:inner 0]])))
     ;; :refer awareness:
     (doseq [[sym var-ref] ns-mappings

--- a/src/formatting_stack/formatters/trivial_ns_duplicates.clj
+++ b/src/formatting_stack/formatters/trivial_ns_duplicates.clj
@@ -9,7 +9,7 @@
    [formatting-stack.formatters.how-to-ns]
    [formatting-stack.protocols.formatter :as formatter]
    [formatting-stack.protocols.linter :as linter]
-   [formatting-stack.util :refer [ensure-coll ensure-sequential process-in-parallel! rcomp read-ns-decl]]
+   [formatting-stack.util :refer [ensure-coll ensure-sequential process-in-parallel! rcomp read-ns-decl unlimited-pr-str]]
    [formatting-stack.util.diff :as diff :refer [diff->line-numbers]]
    [formatting-stack.util.ns :as util.ns :refer [replace-ns-form! write-ns-replacement!]]
    [medley.core :refer [deep-merge]]
@@ -134,13 +134,6 @@
                                               (apply list (first x) all-forms))))))]
     (when-not (= replacement ns-form)
       replacement)))
-
-(defn unlimited-pr-str
-  "#'clojure.core/pr-str with no print limits"
-  [s]
-  (binding [*print-length* nil
-            *print-level* nil]
-    (pr-str s)))
 
 (speced/defn ^{::speced/spec (complement #{"nil"})} duplicate-cleaner [ns-form]
   (some-> ns-form remove-exact-duplicates unlimited-pr-str))

--- a/src/formatting_stack/formatters/trivial_ns_duplicates.clj
+++ b/src/formatting_stack/formatters/trivial_ns_duplicates.clj
@@ -135,8 +135,15 @@
     (when-not (= replacement ns-form)
       replacement)))
 
+(defn unlimited-pr-str
+  "#'clojure.core/pr-str with no print limits"
+  [s]
+  (binding [*print-length* nil
+            *print-level* nil]
+    (pr-str s)))
+
 (speced/defn ^{::speced/spec (complement #{"nil"})} duplicate-cleaner [ns-form]
-  (some-> ns-form remove-exact-duplicates pr-str))
+  (some-> ns-form remove-exact-duplicates unlimited-pr-str))
 
 (defn replaceable-ns-form
   [how-to-ns-opts filename]

--- a/src/formatting_stack/util.clj
+++ b/src/formatting_stack/util.clj
@@ -167,3 +167,10 @@
   [pred coll]
   (let [switch (reductions not= true (map pred coll (rest coll)))]
     (map (partial map first) (partition-by second (map list coll switch)))))
+
+(defn unlimited-pr-str
+  "#'clojure.core/pr-str with no print limits"
+  [s]
+  (binding [*print-length* nil
+            *print-level* nil]
+    (pr-str s)))

--- a/test/unit/formatting_stack/formatters/trivial_ns_duplicates.clj
+++ b/test/unit/formatting_stack/formatters/trivial_ns_duplicates.clj
@@ -113,3 +113,24 @@
 
     "(ns foo (:require #?(:clj foo :cljs bar) [#?(:clj foo :cljs bar)]))"
     nil))
+
+(deftest duplicate-cleaner
+  (let [input '(ns foo
+                 (:require
+                  [a :refer [a]]
+                  [a :refer [a]]
+                  [b :refer [b]]))
+        expected "(ns foo (:require [a :refer [a]] [b :refer [b]]))"]
+
+    ;; override user settings
+    (binding [*print-length* nil
+              *print-level* nil]
+      (is (= expected (sut/duplicate-cleaner input)))
+
+      (testing "not affected by *print-length*"
+        (binding [*print-length* 1]
+          (is (= expected (sut/duplicate-cleaner input)))))
+
+      (testing "not affected by *print-level*"
+        (binding [*print-level* 1]
+          (is (= expected (sut/duplicate-cleaner input))))))))

--- a/test/unit/formatting_stack/util.clj
+++ b/test/unit/formatting_stack/util.clj
@@ -62,3 +62,19 @@
     #(< 2 (- %2 %1))
     '(1 2 3 8 9 10)
     '((1 2 3) (8 9 10))))
+
+(deftest unlimited-pr-str
+  (let [input [1 2 [3 4 [5 6]]]
+        expected "[1 2 [3 4 [5 6]]]"]
+    ;; override user settings
+    (binding [*print-length* nil
+              *print-level* nil]
+      (is (= expected (sut/unlimited-pr-str input)))
+
+      (testing "not affected by *print-length*"
+        (binding [*print-length* 1]
+          (is (= expected (sut/unlimited-pr-str input)))))
+
+      (testing "not affected by *print-level*"
+        (binding [*print-level* 1]
+          (is (= expected (sut/unlimited-pr-str input))))))))


### PR DESCRIPTION
## Brief

Reproduced #192 here (see [failing test](https://app.circleci.com/pipelines/github/nedap/formatting-stack/583/workflows/b7bcb8c7-222c-4388-9c40-bf080f80b668/jobs/2794)).

Fixed by fixing `*print-length*` and `*print-level*` to `nil` when printing the namespace. 

<!-- Which issue does this PR fix? Ideally, create an issue if there was none, so the problem in question is well stated. -->

## QA plan

<!-- Please state a reproducible plan to prove this PR works. Attach screenshots, gifs, etc. if needed. Occasionally, sufficient test coverage removes the need for QAing. -->

## Author checklist

<!-- Please, before publicizing your PR, open it as a "WIP PR", and then review it using the following. -->

* [ ] I have QAed the functionality
* [x] The PR has a reasonably reviewable size and a meaningful commit history
* [x] I have run the [branch formatter](https://github.com/nedap/formatting-stack/blob/332a419034ab46fad526a5592f4257353bd695b6/src/formatting_stack/branch_formatter.clj) and observed no new/significative warnings
* [x] The build passes
* [x] I have self-reviewed the PR prior to assignment
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [x] Correctness
  * [x] Robustness (red paths, failure handling etc)
  * [x] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
  * [ ] Cross-compatibility (Clojure/ClojureScript)

## Reviewer checklist

* [ ] I have checked out this branch and reviewed it locally, running it
* [ ] I have QAed the functionality
* [ ] I have reviewed the PR
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [ ] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
  * [ ] Cross-compatibility (Clojure/ClojureScript)
