### PR TITLE
Upgrade refactor-nrepl

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,11 +106,6 @@ workflows:
           lein_test_command: lein with-profile -user,-dev,+ci,+refactor-nrepl do clean, test
           <<: *test_code_filters
       - test_code:
-          name: "JDK 8 including refactor-nrepl (at its latest version)"
-          jdk_version: openjdk8
-          lein_test_command: lein with-profile -user,-dev,+ci,+refactor-nrepl-latest do clean, test
-          <<: *test_code_filters
-      - test_code:
           name: "JDK 8 excluding refactor-nrepl"
           jdk_version: openjdk8
           lein_test_command: lein with-profile -user,-dev,+ci do clean, test
@@ -124,11 +119,6 @@ workflows:
           name: "JDK 11 including refactor-nrepl"
           jdk_version: openjdk11
           lein_test_command: lein with-profile -user,-dev,+ci,+refactor-nrepl do clean, test
-          <<: *test_code_filters
-      - test_code:
-          name: "JDK 11 including refactor-nrepl (at its latest version)"
-          jdk_version: openjdk11
-          lein_test_command: lein with-profile -user,-dev,+ci,+refactor-nrepl-latest do clean, test
           <<: *test_code_filters
       - test_code:
           name: "JDK 11 excluding refactor-nrepl"

--- a/project.clj
+++ b/project.clj
@@ -124,15 +124,10 @@
                                      :resource-paths ["test-resources-extra"
                                                       "test-resources"]}
 
-             :refactor-nrepl        {:dependencies [[refactor-nrepl "2.4.0"]]
-                                     ;; exercise cider-nrepl as of those days:
-                                     :plugins      [[cider/cider-nrepl "0.22.0"]]}
-
-             ;; There was a 18 month gap between 2.4.0 and 2.5.0, hence the extra build
-             :refactor-nrepl-latest {:dependencies [[refactor-nrepl "2.5.0"]]
-                                     ;; exercise the latest cider-nrepl, increasingly typical
-                                     ;; (and shipped with this refactor-nrepl):
-                                     :plugins      [[cider/cider-nrepl "0.24.0"]]}
+             :refactor-nrepl        {:dependencies [[refactor-nrepl "3.0.0"]
+                                                    [nrepl "0.9.0-beta3"]]
+                                     ;; cider-nrepl is a :provided dependency from refactor-nrepl.
+                                     :plugins      [[cider/cider-nrepl "0.27.2" :exclusions [nrepl]]]}
 
              :ncrw                  {:global-vars    {*assert* true} ;; `ci.release-workflow` relies on runtime assertions
                                      :source-paths   ^:replace []


### PR DESCRIPTION
## Brief

Uses latest, which since is compatible with all sorts of nREPL clients (modern and legacy alike) makes unnecessary the extended profile/matrix.

The relevant changes for f-s is the reduced chance for false positives when cleaning up a ns form. This makes our workarounds around refactor-nrepl less necessary, however I wouldn't particularly recommend removing them (at least for a while; I'd like to increase test coverage for that area of refactor-nrepl first).

## QA plan

None. There aren't breaking changes: https://github.com/clojure-emacs/refactor-nrepl/blob/a3f9de809b1246101786ec6160df3b8c66585f74/CHANGELOG.md#300-2021-10-25

## Author checklist

<!-- Please, before publicizing your PR, open it as a "WIP PR", and then review it using the following. -->

* [ ] I have QAed the functionality
* [x] The PR has a reasonably reviewable size and a meaningful commit history
* [ ] I have run the [branch formatter](https://github.com/nedap/formatting-stack/blob/332a419034ab46fad526a5592f4257353bd695b6/src/formatting_stack/branch_formatter.clj) and observed no new/significative warnings
* [x] The build passes
* [x] I have self-reviewed the PR prior to assignment
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [x] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [x] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [x] Breaking API changes
  * [x] Cross-compatibility (Clojure/ClojureScript)

## Reviewer checklist

* [ ] I have checked out this branch and reviewed it locally, running it
* [ ] I have QAed the functionality
* [ ] I have reviewed the PR
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [ ] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
  * [ ] Cross-compatibility (Clojure/ClojureScript)
