### PR TITLE
Upgrade refactor-nrepl

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -124,7 +124,7 @@
                                      :resource-paths ["test-resources-extra"
                                                       "test-resources"]}
 
-             :refactor-nrepl        {:dependencies [[refactor-nrepl "3.0.0"]
+             :refactor-nrepl        {:dependencies [[refactor-nrepl "3.1.0"]
                                                     [nrepl "0.9.0-beta3"]]
                                      ;; cider-nrepl is a :provided dependency from refactor-nrepl.
                                      :plugins      [[cider/cider-nrepl "0.27.2" :exclusions [nrepl]]]}

--- a/src/formatting_stack/formatters/clean_ns.clj
+++ b/src/formatting_stack/formatters/clean_ns.clj
@@ -48,7 +48,9 @@
 (def default-nrepl-opts
   (delay
     (-> @default-nrepl-config-opts
-        (assoc :prefix-rewriting false))))
+        (assoc :prefix-rewriting false
+               :print-right-margin nil
+               :print-miser-width nil))))
 
 (def default-namespaces-that-should-never-cleaned
   #{'user 'dev})


### PR DESCRIPTION
## Brief

3.1.0 introduces new options making it finally able to match how-to-ns. This commit uses them, since the default is different.

However it's not recommended to remove our how-to-ns dependency yet, since refactor-nrepl's .cljc formatting is a bit odd.

## QA plan

None; this commit simply uses options as documented.

## Author checklist

<!-- Please, before publicizing your PR, open it as a "WIP PR", and then review it using the following. -->

* [ ] I have QAed the functionality
* [x] The PR has a reasonably reviewable size and a meaningful commit history
* [ ] I have run the [branch formatter](https://github.com/nedap/formatting-stack/blob/332a419034ab46fad526a5592f4257353bd695b6/src/formatting_stack/branch_formatter.clj) and observed no new/significative warnings
* [x] The build passes
* [x] I have self-reviewed the PR prior to assignment
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [x] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [x] Test coverage
  * [x] Spec coverage
  * [x] Documentation
  * [x] Security
  * [x] Performance
  * [x] Breaking API changes
  * [x] Cross-compatibility (Clojure/ClojureScript)

## Reviewer checklist

* [ ] I have checked out this branch and reviewed it locally, running it
* [ ] I have QAed the functionality
* [ ] I have reviewed the PR
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [ ] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
  * [ ] Cross-compatibility (Clojure/ClojureScript)
