### PR TITLE
replace exclusion by managed-dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -120,8 +120,8 @@
              ;; `dev` in :test is important - a test depends on it:
              :test                  {:source-paths   ["dev"]
                                      :dependencies   [[com.nedap.staffing-solutions/utils.test "1.6.2"]
-                                                      [nubank/matcher-combinators "1.0.1"
-                                                       :exclusions [commons-codec]]]
+                                                      [nubank/matcher-combinators "1.0.1"]]
+                                     :managed-dependencies [[commons-codec "1.11"]]
                                      :jvm-opts       ["-Dclojure.core.async.go-checking=true"
                                                       "-Duser.language=en-US"]
                                      :resource-paths ["test-resources-extra"
@@ -130,7 +130,7 @@
              :refactor-nrepl        {:dependencies [[refactor-nrepl "3.5.2"]
                                                     [nrepl "0.9.0"]]
                                      ;; cider-nrepl is a :provided dependency from refactor-nrepl.
-                                     :plugins      [[cider/cider-nrepl "0.28.2" :exclusions [nrepl]]]}
+                                     :plugins      [[cider/cider-nrepl "0.28.2"]]}
 
              :ncrw                  {:global-vars    {*assert* true} ;; `ci.release-workflow` relies on runtime assertions
                                      :source-paths   ^:replace []

--- a/project.clj
+++ b/project.clj
@@ -130,7 +130,9 @@
              :refactor-nrepl        {:dependencies [[refactor-nrepl "3.5.2"]
                                                     [nrepl "0.9.0"]]
                                      ;; cider-nrepl is a :provided dependency from refactor-nrepl.
-                                     :plugins      [[cider/cider-nrepl "0.28.2"]]}
+                                     :plugins      [[cider/cider-nrepl "0.28.2"
+                                                     ;; not excluding nrepl will cause conflicting versions
+                                                     :exclusions [nrepl]]]}
 
              :ncrw                  {:global-vars    {*assert* true} ;; `ci.release-workflow` relies on runtime assertions
                                      :source-paths   ^:replace []


### PR DESCRIPTION
## Brief

Remove last occurrences of exclusions. Using exclusions are difficult (saying what you don't want to include instead of saying what you _do_ want). 

We've implemented this practise almost everywhere, but i noticed these two lingering

<!-- Which issue does this PR fix? Ideally, create an issue if there was none, so the problem in question is well stated. -->

## QA plan

<!-- Please state a reproducible plan to prove this PR works. Attach screenshots, gifs, etc. if needed. Occasionally, sufficient test coverage removes the need for QAing. -->

## Author checklist

<!-- Please, before publicizing your PR, open it as a "WIP PR", and then review it using the following. -->

* [ ] I have QAed the functionality
* [ ] The PR has a reasonably reviewable size and a meaningful commit history
* [ ] I have run the [branch formatter](https://github.com/nedap/formatting-stack/blob/332a419034ab46fad526a5592f4257353bd695b6/src/formatting_stack/branch_formatter.clj) and observed no new/significative warnings
* [ ] The build passes
* [ ] I have self-reviewed the PR prior to assignment
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [ ] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
  * [ ] Cross-compatibility (Clojure/ClojureScript)

## Reviewer checklist

* [ ] I have checked out this branch and reviewed it locally, running it
* [ ] I have QAed the functionality
* [ ] I have reviewed the PR
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [ ] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
  * [ ] Cross-compatibility (Clojure/ClojureScript)
