### PR TITLE
`filename->ns`: avoid processing cljs files

### DIFF
--- a/src/formatting_stack/strategies/impl.clj
+++ b/src/formatting_stack/strategies/impl.clj
@@ -60,8 +60,13 @@
     (the-ns ns-name)
     (catch Exception _)))
 
-(speced/defn ^::speced/nilable ^Namespace filename->ns [^string? filename]
-  (some-> filename read-ns-decl parse/name-from-ns-decl safe-the-ns))
+(speced/defn ^::speced/nilable ^Namespace filename->ns [^String filename]
+  ;; sometimes, cider-nrepl or other tooling can create (essentially empty) `Namespace` objects for .cljs files.
+  ;; These are not only useless, but prevent us from processing .cljs namespaces properly
+  ;; (i.e. parse their contents instead of inspecting the JVM runtime).
+  ;; So, we disregard .cljs files:
+  (when-not (-> filename (.endsWith ".cljs"))
+    (some-> filename read-ns-decl parse/name-from-ns-decl safe-the-ns)))
 
 (defn readable?
   "Is this file readable to clojure.tools.reader? (given custom reader tags, unbalanced parentheses or such)"


### PR DESCRIPTION
## Context

I had trouble running f-s in a pure-cljs project - nothing would be formatted/linted.

This was because a particular combination of nREPL tooling was creating `clojure.lang.Namespace` objects for cljs namespaces. Those are empty/useless (the cljs compiler uses plain maps instead) and were breaking dependent logic.

This PR fixes that. I've tested it locally.

## QA plan

None suggested

## Author checklist

<!-- Please, before publicizing your PR, open it as a "WIP PR", and then review it using the following. -->

* [x] I have QAed the functionality
* [x] The PR has a reasonably reviewable size and a meaningful commit history
* [ ] I have run the [branch formatter](https://github.com/nedap/formatting-stack/blob/332a419034ab46fad526a5592f4257353bd695b6/src/formatting_stack/branch_formatter.clj) and observed no new/significative warnings
* [ ] The build passes
* [x] I have self-reviewed the PR prior to assignment
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [x] Correctness
  * [x] Robustness (red paths, failure handling etc)
  * [x] Test coverage
  * [x] Spec coverage
  * [x] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
  * [ ] Cross-compatibility (Clojure/ClojureScript)

## Reviewer checklist

* [ ] I have checked out this branch and reviewed it locally, running it
* [ ] I have QAed the functionality
* [ ] I have reviewed the PR
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [ ] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
  * [ ] Cross-compatibility (Clojure/ClojureScript)

Cheers - V